### PR TITLE
Document use of the maintainers field

### DIFF
--- a/tutorial/examples/0.package.py
+++ b/tutorial/examples/0.package.py
@@ -28,6 +28,10 @@ class Mpileaks(Package):
     homepage = "http://www.example.com"
     url      = "https://github.com/LLNL/mpileaks/releases/download/v1.0/mpileaks-1.0.tar.gz"
 
+    # FIXME: Add a list of GitHub accounts to
+    # notify when the package is updated.
+    # maintainers = ['github_user1', 'github_user2']
+
     version('1.0', sha256='2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825')
 
     # FIXME: Add dependencies if required.

--- a/tutorial/examples/1.package.py
+++ b/tutorial/examples/1.package.py
@@ -13,6 +13,8 @@ class Mpileaks(Package):
     homepage = "https://github.com/LLNL/mpileaks"
     url      = "https://github.com/LLNL/mpileaks/releases/download/v1.0/mpileaks-1.0.tar.gz"
 
+    maintainers = ['adamjstewart']
+
     version('1.0', sha256='2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825')
 
     # FIXME: Add dependencies if required.

--- a/tutorial/examples/2.package.py
+++ b/tutorial/examples/2.package.py
@@ -13,6 +13,8 @@ class Mpileaks(Package):
     homepage = "https://github.com/LLNL/mpileaks"
     url      = "https://github.com/LLNL/mpileaks/releases/download/v1.0/mpileaks-1.0.tar.gz"
 
+    maintainers = ['adamjstewart']
+
     version('1.0', sha256='2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825')
 
     depends_on('mpi')

--- a/tutorial/examples/3.package.py
+++ b/tutorial/examples/3.package.py
@@ -13,6 +13,8 @@ class Mpileaks(Package):
     homepage = "https://github.com/LLNL/mpileaks"
     url      = "https://github.com/LLNL/mpileaks/releases/download/v1.0/mpileaks-1.0.tar.gz"
 
+    maintainers = ['adamjstewart']
+
     version('1.0', sha256='2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825')
 
     depends_on('mpi')

--- a/tutorial/examples/4.package.py
+++ b/tutorial/examples/4.package.py
@@ -13,6 +13,8 @@ class Mpileaks(Package):
     homepage = "https://github.com/LLNL/mpileaks"
     url      = "https://github.com/LLNL/mpileaks/releases/download/v1.0/mpileaks-1.0.tar.gz"
 
+    maintainers = ['adamjstewart']
+
     version('1.0', sha256='2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825')
 
     depends_on('mpi')

--- a/tutorial/examples/5.package.py
+++ b/tutorial/examples/5.package.py
@@ -13,6 +13,8 @@ class Mpileaks(Package):
     homepage = "https://github.com/LLNL/mpileaks"
     url      = "https://github.com/LLNL/mpileaks/releases/download/v1.0/mpileaks-1.0.tar.gz"
 
+    maintainers = ['adamjstewart']
+
     version('1.0', sha256='2e34cc4505556d1c1f085758e26f2f8eea0972db9382f051b2dcfb1d7d9e1825')
 
     variant('stackstart', values=int, default=0,

--- a/tutorial_packaging.rst
+++ b/tutorial_packaging.rst
@@ -141,11 +141,18 @@ We can bring the ``package.py`` file back into our ``EDITOR`` with the
 
    $ spack edit mpileaks
 
-Let's remove some of the ``FIXME`` comments, add links to the mpileaks
-homepage, and document what mpileaks does.  I'm also going to cut out the
-Copyright clause at this point to keep this tutorial document shorter,
-but you shouldn't do that normally.  The results of these changes can be
-found in ``$SPACK_ROOT/lib/spack/docs/tutorial/examples/1.package.py``
+Let's remove some of the ``FIXME`` comments, add a link to the mpileaks
+homepage, and document what mpileaks does. Let's also add a maintainer
+to the package. The ``maintainers`` field is a comma-separated list of
+GitHub accounts of users who want to be notified when a change is made
+to a package. This is useful for developers who maintain a Spack package
+for their own software, and for users who rely on a piece of software
+and want to ensure that the package doesn't break.
+
+I'm also going to cut out the Copyright clause at this point to keep
+this tutorial document shorter, but you shouldn't do that normally.
+The results of these changes can be found in
+``$SPACK_ROOT/lib/spack/docs/tutorial/examples/1.package.py``
 and are displayed below.  Make these changes to your ``package.py``:
 
 .. literalinclude:: tutorial/examples/1.package.py
@@ -166,6 +173,8 @@ allow Spack to provide some documentation on this package to other users:
        MPI_Datatypes.
 
    Homepage: https://github.com/LLNL/mpileaks
+
+   Maintainers: @adamjstewart
 
    Tags:
        None
@@ -505,7 +514,7 @@ powerful class for querying information about what we're building.  For
 example, you could use the spec to query information about how a
 package's dependencies were built, or what compiler was being used, or
 what version of a package is being installed.  Full documentation can be
-found in the `Packaging Guide <https://spack.readthedocs.io/en/latest/packaging_guide.html#packaging-guide>`_, 
+found in the `Packaging Guide <https://spack.readthedocs.io/en/latest/packaging_guide.html#packaging-guide>`_,
 but here's some quick snippets with common queries:
 
 - Am I building ``mpileaks`` version ``1.1`` or greater?


### PR DESCRIPTION
Split off of https://github.com/spack/spack/pull/12270 now that the tutorial docs are in a separate repo.

@tgamblin I removed the "automatically" from the phrasing until the maintainers GitHub action actually works.

@alalazo I will have many more updates to the Packaging Tutorial, just wanted to get this out of the way first. I'll let you know when it's ready to update for Ubuntu 18.