### PR TITLE
Fix missing code block in environments tutorial

### DIFF
--- a/tutorial_environments.rst
+++ b/tutorial_environments.rst
@@ -747,7 +747,7 @@ It also prints the zlib version.
 
 All you need to do is build and run it:
 
-.. code-block: console
+.. code-block:: console
 
     $ mpicc ./mpi-hello.c
     $ mpirun -n 4 ./a.out


### PR DESCRIPTION
One of the `code-block` directives in the environments tutorial was missing a double colon. The associated code block was missing from the HTML documentation.