### PR TITLE
README: Update LLNL release number to Apache-2.0/MIT version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ See [LICENSE-MIT](https://github.com/spack/spack/blob/develop/LICENSE-MIT),
 
 SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-LLNL-CODE-647188
+LLNL-CODE-811652


### PR DESCRIPTION
The release number in the README had not been updated since we did the
relicense to Apache-2.0 OR MIT in v0.12.0. LLNL-CODE-811652 is Spack's
new LLNL release number.