### PR TITLE
Add init spack script

### DIFF
--- a/outputs/init_spack.sh
+++ b/outputs/init_spack.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ ! -d spack ]; then
+    git clone https://github.com/spack/spack
+    cd spack
+    git checkout releases/v0.15
+else
+    cd spack
+fi
+
+. share/spack/setup-env.sh
+
+spack mirror add tutorial /mirror
+spack gpg trust /mirror/public.key
+spack config add 'config:suppress_gpg_warnings:true'


### PR DESCRIPTION
This adds `init_spack.sh` script to be used by subsections to get Spack set up before running commands.