### PR TITLE
spack env deactivate not showing up in test

### DIFF
--- a/outputs/environments/env-status-2.out
+++ b/outputs/environments/env-status-2.out
@@ -1,4 +1,4 @@
-$ despacktivate      # short alias for 'spack env deactivate'
+$ despacktivate      # short alias for spack env deactivate
 $ spack env status
 ==> No active environment
 $ spack find


### PR DESCRIPTION
in section https://spack-tutorial.readthedocs.io/en/latest/tutorial_environments.html#creating-and-activating-environments 

the documentation is not rendering `'spack env deactivate'` so this PR is removing the quote.