### PR TITLE
Fix "recursive" argument in "find_libraries" example.

### DIFF
--- a/tutorial_advanced_packaging.rst
+++ b/tutorial_advanced_packaging.rst
@@ -314,7 +314,7 @@ follow this naming scheme must implement this function themselves, e.g.
     def libs(self):
         shared = "+shared" in self.spec
         return find_libraries(
-            "libopencv_*", root=self.prefix, shared=shared, recurse=True
+            "libopencv_*", root=self.prefix, shared=shared, recursive=True
         )
 
 This issue is common for packages which implement an interface (i.e.


### PR DESCRIPTION
Hi,

I just stumbled on this typo while working on a `libs` property for a package.

Rémi