### PR TITLE
SC20 updates for Configuration Tutorial

### DIFF
--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -391,7 +391,7 @@ configuration file. First, we will look at the default
 
 
 This sets the default preferences for compilers and for providers of
-virtual dependencies. To illustrate how this works, suppose we want to
+virtual packages. To illustrate how this works, suppose we want to
 change the preferences to prefer the Clang compiler and to prefer
 MPICH over OpenMPI. Currently, we prefer GCC and OpenMPI.
 


### PR DESCRIPTION
Tested locally to make sure the `:emphasize-lines:` numbers are correct.

Mostly formatting changes, but I also added a section on using `spack external find`. Let me know if we want more detail than that.

For future tutorials, we will need to update the `packages.yaml` format and the list of supported compilers, but those are fine for now since we're using an older release for this tutorial.

One other section I thought about adding was overriding the default `target:` to use `x86_64` instead of the specific microarchitecture that Spack detects. This is a common use case for users on heterogenous clusters. However, this is problematic because we use a mixed compiler for most of this tutorial, which doesn't support specific microarchs anyway. Is it still worth adding an example with GCC that shows how to do it?