### PR TITLE
scripts: update tutorial scripts to work outside of a container

### DIFF
--- a/outputs/defs.sh
+++ b/outputs/defs.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-raw_outputs=/project/raw
+# if in a container, put stuff in the bindmounted
+# /project directory (see Makefile).  Otherwise use ${PWD}
+if [ -d /project ]; then
+    PROJECT=/project
+else
+    PROJECT="${PWD}"
+fi
+
+raw_outputs="${PROJECT}/raw"
 
 example() {
     if [[ "$1" == "-tee" ]]; then

--- a/outputs/modules.sh
+++ b/outputs/modules.sh
@@ -104,7 +104,7 @@ module load netlib-lapack openblas
 example -tee modules/lmod-intro-conflict  "module list"
 
 
-cp /project/module-configs/lmod.1.yaml ~/.spack/modules.yaml
+cp ${PROJECT}/module-configs/lmod.1.yaml ~/.spack/modules.yaml
 example      modules/lmod-refresh-1     "spack module lmod refresh --delete-tree -y"
 module purge
 module unuse $HOME/spack/share/spack/modules/linux-ubuntu18.04-x86_64
@@ -138,7 +138,7 @@ module load netlib-scalapack/2.1.0-netlib-lapack
 example -tee modules/lapack-conflict    "module list"
 
 
-cp /project/module-configs/lmod.2.yaml ~/.spack/modules.yaml
+cp ${PROJECT}/module-configs/lmod.2.yaml ~/.spack/modules.yaml
 example -tee modules/lmod-refresh-2    "module purge"
 example -tee modules/lmod-refresh-2    "spack module lmod refresh --delete-tree -y"
 

--- a/outputs/packaging.sh
+++ b/outputs/packaging.sh
@@ -16,11 +16,11 @@ example packaging/create     "spack create https://github.com/LLNL/mpileaks/rele
 
 example packaging/install-mpileaks-1  "spack install mpileaks"
 
-cp /project/package-py-files/1.package.py $mpileaks_package_py
+cp ${PROJECT}/package-py-files/1.package.py $mpileaks_package_py
 example packaging/info-mpileaks       "spack info mpileaks"
 
 spack uninstall -ay mpileaks
-cp /project/package-py-files/2.package.py $mpileaks_package_py
+cp ${PROJECT}/package-py-files/2.package.py $mpileaks_package_py
 example packaging/install-mpileaks-2  "spack install mpileaks"
 
 stage_dir=$(spack location -s mpileaks)
@@ -31,10 +31,10 @@ example packaging/build-output        "cat $stage_dir/spack-build-out.txt"
 #spack cd mpileaks
 #echo "configure --prefix=$prefix" | example packaging/build-env-configure "spack build-env mpileaks bash"
 
-cp /project/package-py-files/3.package.py $mpileaks_package_py
+cp ${PROJECT}/package-py-files/3.package.py $mpileaks_package_py
 example packaging/install-mpileaks-3  "spack install mpileaks"
 
-cp /project/package-py-files/4.package.py $mpileaks_package_py
+cp ${PROJECT}/package-py-files/4.package.py $mpileaks_package_py
 example packaging/install-mpileaks-4  "spack install --verbose mpileaks stackstart=4"
 
 example packaging/cleanup  "spack uninstall -ay mpileaks"

--- a/outputs/scripting.sh
+++ b/outputs/scripting.sh
@@ -24,7 +24,7 @@ echo "exit()
 
 fake_example scripting/edit '$EDITOR find_exclude.py' "/bin/true"
 
-cat <<EOF | tee /project/raw/0.find_exclude.py.example find_exclude.py
+cat <<EOF | tee ${PROJECT}/raw/0.find_exclude.py.example find_exclude.py
 from spack.spec import Spec
 import spack.store
 import spack.cmd
@@ -41,11 +41,11 @@ EOF
 
 example scripting/find-exclude-1 "spack python find_exclude.py %gcc ^mpich"
 
-{ echo "#!/usr/bin/env spack python" & cat find_exclude.py; } | tee /project/raw/1.find_exclude.py.example find_exclude.py
+{ echo "#!/usr/bin/env spack python" & cat find_exclude.py; } | tee ${PROJECT}/raw/1.find_exclude.py.example find_exclude.py
 
 example scripting/find-exclude-2 "chmod u+x find_exclude.py"
 example scripting/find-exclude-2 "./find_exclude.py %gcc ^mpich"
 
-sed s'|spack python|spack-python|' find_exclude.py | tee /project/raw/2.find_exclude.py.example find_exclude.py
+sed s'|spack python|spack-python|' find_exclude.py | tee  ${PROJECT}/raw/2.find_exclude.py.example find_exclude.py
 
 example scripting/find-exclude-3 "./find_exclude.py %gcc ^mpich"


### PR DESCRIPTION
Scripts were assuming that `/project` existed, but it only exists when we bindmount it into the container.  This makes the scripts work in-place in our AWS instance, as well.