### PR TITLE
dev workflows: more specific hwloc uninstall

### DIFF
--- a/outputs/dev.sh
+++ b/outputs/dev.sh
@@ -29,7 +29,7 @@ example dev/dev-build-1 "spack dev-build hwloc@master"
 
 example dev/info "spack info hwloc"
 
-echo y | example dev/dev-build-2 "spack uninstall hwloc"
+echo y | example dev/dev-build-2 "spack uninstall hwloc@master"
 fake_example dev/dev-build-2 "spack dev-build --until configure --drop-in bash hwloc@master" "spack dev-build --until configure hwloc@master"
 
 export EDITOR="bash -c exit 0"


### PR DESCRIPTION
There may be other versions of `hwloc` installed from earlier sections. This ensures we uninstall the correct one.