### PR TITLE
Configuration tutorial section updates

### DIFF
--- a/outputs/config/0.compiler_flags.out
+++ b/outputs/config/0.compiler_flags.out
@@ -5,12 +5,13 @@ json-fortran%clang@6.0.0-gfortran
 
 Concretized
 --------------------------------
-json-fortran@7.1.0%clang@6.0.0-gfortran cppflags="-g"  build_type=RelWithDebInfo arch=linux-ubuntu18.04-x86_64
-    ^cmake@3.17.3%clang@6.0.0-gfortran cppflags="-g" ~doc+ncurses+openssl+ownlibs~qt arch=linux-ubuntu18.04-x86_64
+json-fortran@7.1.0%clang@6.0.0-gfortran cppflags="-g" ~ipo build_type=RelWithDebInfo arch=linux-ubuntu18.04-x86_64
+    ^cmake@3.18.4%clang@6.0.0-gfortran cppflags="-g" ~doc+ncurses+openssl+ownlibs~qt patches=bf695e3febb222da2ed94b3beea600650e4318975da90e4a71d6f31a6d5d8c3d arch=linux-ubuntu18.04-x86_64
         ^ncurses@6.2%clang@6.0.0-gfortran cppflags="-g" ~symlinks+termlib arch=linux-ubuntu18.04-x86_64
             ^pkgconf@1.7.3%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
-        ^openssl@1.1.1g%clang@6.0.0-gfortran cppflags="-g" +systemcerts arch=linux-ubuntu18.04-x86_64
-            ^perl@5.30.3%clang@6.0.0-gfortran cppflags="-g" +cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+        ^openssl@1.1.1h%clang@6.0.0-gfortran cppflags="-g" +systemcerts arch=linux-ubuntu18.04-x86_64
+            ^perl@5.32.0%clang@6.0.0-gfortran cppflags="-g" +cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+                ^berkeley-db@18.1.40%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                 ^gdbm@1.18.1%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                     ^readline@8.0%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
             ^zlib@1.2.11%clang@6.0.0-gfortran cppflags="-g" +optimize+pic+shared arch=linux-ubuntu18.04-x86_64

--- a/outputs/config/0.externals.out
+++ b/outputs/config/0.externals.out
@@ -5,6 +5,5 @@ hdf5
 
 Concretized
 --------------------------------
-hdf5@1.10.6%gcc@7.5.0~cxx~debug~fortran~hl~mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+hdf5@1.10.7%gcc@7.5.0~cxx~debug~fortran~hl~java~mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
     ^zlib@1.2.8%gcc@7.5.0+optimize+pic~shared arch=linux-ubuntu18.04-x86_64
-

--- a/outputs/config/0.prefs.out
+++ b/outputs/config/0.prefs.out
@@ -5,10 +5,10 @@ hdf5
 
 Concretized
 --------------------------------
-hdf5@1.10.6%gcc@7.5.0~cxx~debug~fortran~hl+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
-    ^openmpi@3.1.6%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~memchecker~pmi~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
+hdf5@1.10.7%gcc@7.5.0~cxx~debug~fortran~hl~java+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+    ^openmpi@3.1.6%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
         ^hwloc@1.11.11%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
-            ^libpciaccess@0.13.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+            ^libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
                 ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
                     ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
                         ^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
@@ -16,13 +16,13 @@ hdf5@1.10.6%gcc@7.5.0~cxx~debug~fortran~hl+mpi+pic+shared~szip~threadsafe api=no
                 ^util-macros@1.19.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
             ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
                 ^libiconv@1.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-                ^xz@5.2.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+                ^xz@5.2.5%gcc@7.5.0~pic arch=linux-ubuntu18.04-x86_64
                 ^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64
-            ^numactl@2.0.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+            ^numactl@2.0.14%gcc@7.5.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94 arch=linux-ubuntu18.04-x86_64
                 ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-                    ^perl@5.30.3%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+                    ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+                        ^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
                         ^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
                             ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
                                 ^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-x86_64
                 ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-

--- a/outputs/config/1.externals.out
+++ b/outputs/config/1.externals.out
@@ -5,6 +5,5 @@ hdf5%clang
 
 Concretized
 --------------------------------
-hdf5@1.10.6%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl~mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+hdf5@1.10.7%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl~java~mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
     ^zlib@1.2.11%clang@6.0.0-gfortran cppflags="-g" +optimize+pic~shared arch=linux-ubuntu18.04-x86_64
-

--- a/outputs/config/1.prefs.out
+++ b/outputs/config/1.prefs.out
@@ -5,12 +5,13 @@ hdf5
 
 Concretized
 --------------------------------
-hdf5@1.10.6%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
-    ^mpich@3.3.2%clang@6.0.0-gfortran cppflags="-g" +hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
+hdf5@1.10.7%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl~java+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+    ^mpich@3.3.2%clang@6.0.0-gfortran cppflags="-g" ~argobots+fortran+hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
         ^autoconf@2.69%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
             ^m4@1.4.18%clang@6.0.0-gfortran cppflags="-g" +sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
                 ^libsigsegv@2.12%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
-            ^perl@5.30.3%clang@6.0.0-gfortran cppflags="-g" +cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+            ^perl@5.32.0%clang@6.0.0-gfortran cppflags="-g" +cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+                ^berkeley-db@18.1.40%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                 ^gdbm@1.18.1%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                     ^readline@8.0%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                         ^ncurses@6.2%clang@6.0.0-gfortran cppflags="-g" ~symlinks+termlib arch=linux-ubuntu18.04-x86_64
@@ -20,10 +21,9 @@ hdf5@1.10.6%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl+mpi+pic+sha
             ^libtool@2.4.6%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
             ^texinfo@6.5%clang@6.0.0-gfortran cppflags="-g"  patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1 arch=linux-ubuntu18.04-x86_64
         ^hwloc@2.2.0%clang@6.0.0-gfortran cppflags="-g" ~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
-            ^libpciaccess@0.13.5%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
+            ^libpciaccess@0.16%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                 ^util-macros@1.19.1%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
             ^libxml2@2.9.10%clang@6.0.0-gfortran cppflags="-g" ~python arch=linux-ubuntu18.04-x86_64
                 ^libiconv@1.16%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
-                ^xz@5.2.5%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
+                ^xz@5.2.5%clang@6.0.0-gfortran cppflags="-g" ~pic arch=linux-ubuntu18.04-x86_64
                 ^zlib@1.2.11%clang@6.0.0-gfortran cppflags="-g" +optimize+pic+shared arch=linux-ubuntu18.04-x86_64
-

--- a/outputs/config/2.externals.out
+++ b/outputs/config/2.externals.out
@@ -5,6 +5,5 @@ hdf5%clang
 
 Concretized
 --------------------------------
-hdf5@1.10.6%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl~mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+hdf5@1.10.7%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl~java~mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
     ^zlib@1.2.8%gcc@7.5.0+optimize+pic~shared arch=linux-ubuntu18.04-x86_64
-

--- a/outputs/config/2.prefs.out
+++ b/outputs/config/2.prefs.out
@@ -5,12 +5,13 @@ hdf5
 
 Concretized
 --------------------------------
-hdf5@1.10.6%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl+mpi+pic~shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
-    ^mpich@3.3.2%clang@6.0.0-gfortran cppflags="-g" +hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
+hdf5@1.10.7%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl~java+mpi+pic~shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+    ^mpich@3.3.2%clang@6.0.0-gfortran cppflags="-g" ~argobots+fortran+hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
         ^autoconf@2.69%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
             ^m4@1.4.18%clang@6.0.0-gfortran cppflags="-g" +sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
                 ^libsigsegv@2.12%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
-            ^perl@5.30.3%clang@6.0.0-gfortran cppflags="-g" +cpanm~shared+threads arch=linux-ubuntu18.04-x86_64
+            ^perl@5.32.0%clang@6.0.0-gfortran cppflags="-g" +cpanm~shared+threads arch=linux-ubuntu18.04-x86_64
+                ^berkeley-db@18.1.40%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                 ^gdbm@1.18.1%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                     ^readline@8.0%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                         ^ncurses@6.2%clang@6.0.0-gfortran cppflags="-g" ~symlinks+termlib arch=linux-ubuntu18.04-x86_64
@@ -20,10 +21,9 @@ hdf5@1.10.6%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl+mpi+pic~sha
             ^libtool@2.4.6%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
             ^texinfo@6.5%clang@6.0.0-gfortran cppflags="-g"  patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1 arch=linux-ubuntu18.04-x86_64
         ^hwloc@2.2.0%clang@6.0.0-gfortran cppflags="-g" ~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci~shared arch=linux-ubuntu18.04-x86_64
-            ^libpciaccess@0.13.5%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
+            ^libpciaccess@0.16%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                 ^util-macros@1.19.1%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
             ^libxml2@2.9.10%clang@6.0.0-gfortran cppflags="-g" ~python arch=linux-ubuntu18.04-x86_64
                 ^libiconv@1.16%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
-                ^xz@5.2.5%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
+                ^xz@5.2.5%clang@6.0.0-gfortran cppflags="-g" ~pic arch=linux-ubuntu18.04-x86_64
                 ^zlib@1.2.11%clang@6.0.0-gfortran cppflags="-g" +optimize+pic~shared arch=linux-ubuntu18.04-x86_64
-

--- a/outputs/config/3.externals.out
+++ b/outputs/config/3.externals.out
@@ -5,10 +5,10 @@ hdf5%clang+mpi
 
 Concretized
 --------------------------------
-hdf5@1.10.6%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
-    ^openmpi@3.1.6%clang@6.0.0-gfortran cppflags="-g" ~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~memchecker~pmi~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
+hdf5@1.10.7%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl~java+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+    ^openmpi@3.1.6%clang@6.0.0-gfortran cppflags="-g" ~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
         ^hwloc@1.11.11%clang@6.0.0-gfortran cppflags="-g" ~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci~shared arch=linux-ubuntu18.04-x86_64
-            ^libpciaccess@0.13.5%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
+            ^libpciaccess@0.16%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                 ^libtool@2.4.6%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                     ^m4@1.4.18%clang@6.0.0-gfortran cppflags="-g" +sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
                         ^libsigsegv@2.12%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
@@ -16,13 +16,13 @@ hdf5@1.10.6%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl+mpi+pic+sha
                 ^util-macros@1.19.1%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
             ^libxml2@2.9.10%clang@6.0.0-gfortran cppflags="-g" ~python arch=linux-ubuntu18.04-x86_64
                 ^libiconv@1.16%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
-                ^xz@5.2.5%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
+                ^xz@5.2.5%clang@6.0.0-gfortran cppflags="-g" ~pic arch=linux-ubuntu18.04-x86_64
                 ^zlib@1.2.8%gcc@7.5.0+optimize+pic~shared arch=linux-ubuntu18.04-x86_64
-            ^numactl@2.0.12%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
+            ^numactl@2.0.14%clang@6.0.0-gfortran cppflags="-g"  patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94 arch=linux-ubuntu18.04-x86_64
                 ^autoconf@2.69%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
-                    ^perl@5.30.3%clang@6.0.0-gfortran cppflags="-g" +cpanm~shared+threads arch=linux-ubuntu18.04-x86_64
+                    ^perl@5.32.0%clang@6.0.0-gfortran cppflags="-g" +cpanm~shared+threads arch=linux-ubuntu18.04-x86_64
+                        ^berkeley-db@18.1.40%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                         ^gdbm@1.18.1%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                             ^readline@8.0%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
                                 ^ncurses@6.2%clang@6.0.0-gfortran cppflags="-g" ~symlinks+termlib arch=linux-ubuntu18.04-x86_64
                 ^automake@1.16.2%clang@6.0.0-gfortran cppflags="-g"  arch=linux-ubuntu18.04-x86_64
-

--- a/outputs/config/3.prefs.out
+++ b/outputs/config/3.prefs.out
@@ -5,6 +5,5 @@ hdf5
 
 Concretized
 --------------------------------
-hdf5@1.10.6%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl~mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+hdf5@1.10.7%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl~java~mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
     ^zlib@1.2.11%clang@6.0.0-gfortran cppflags="-g" +optimize+pic~shared arch=linux-ubuntu18.04-x86_64
-

--- a/outputs/config/4.externals.out
+++ b/outputs/config/4.externals.out
@@ -5,7 +5,6 @@ hdf5%clang
 
 Concretized
 --------------------------------
-hdf5@1.10.6%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl+mpi+pic~shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
-    ^mpich@3.3%gcc@7.5.0+hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=c7d4ecf865dccff5b764d9c66b6a470d11b0b1a5b4f7ad1ffa61079ad6b5dede,eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
+hdf5@1.10.7%clang@6.0.0-gfortran cppflags="-g" ~cxx~debug~fortran~hl~java+mpi+pic~shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+    ^mpich@3.3%gcc@7.5.0~argobots+fortran+hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=c7d4ecf865dccff5b764d9c66b6a470d11b0b1a5b4f7ad1ffa61079ad6b5dede,eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
     ^zlib@1.2.8%gcc@7.5.0+optimize+pic~shared arch=linux-ubuntu18.04-x86_64
-

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -702,10 +702,8 @@ Now, only members of the ``fluid_dynamics`` group can use any
 
 .. warning::
 
-   Make sure to delete or move the ``packages.yaml`` you have been
-   editing up to this point. Otherwise, it will change the hashes
-   of your packages, leading to differences in the output of later
-   tutorial sections.
+   You should now ``spack env deactivate`` to avoid changing how
+   specs in later tutorial sections are concretized.
 
 
 -----------------

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -90,8 +90,9 @@ Some facilities manage multiple platforms from a single shared
 file system. In order to handle this, each of the configuration
 scopes listed above has two *sub-scopes*: platform-specific and
 platform-independent. For example, compiler settings can be stored
-in ``compilers.yaml`` configuration files in the following locations:
+in the following locations:
 
+#. ``environment-root-dir/spack.yaml``
 #. ``~/.spack/<platform>/compilers.yaml``
 #. ``~/.spack/compilers.yaml``
 #. ``$SPACK_ROOT/etc/spack/<platform>/compilers.yaml``
@@ -150,11 +151,11 @@ configuration file had a single colon instead of the double colon, it
 would add the GCC version 7.5.0 compiler to whatever other compilers
 were listed in other configuration files.
 
-The schema for a section applies whether that section is an individual
-file or part of an environment, except that the sections are nested 1
-level underneath the top-level 'spack' key in an environment's
-``spack.yaml`` file. For example the above ``compilers.yaml`` could be
-incorporated into an environment's ``spack.yaml`` like so:
+A configuration section appears nearly the same when managed in an
+environment's ``spack.yaml`` file except that the section is nested 1
+level underneath the top-level 'spack' key. For example the above
+``compilers.yaml`` could be incorporated into an environment's
+``spack.yaml`` like so:
 
 .. code-block:: yaml
 
@@ -415,9 +416,9 @@ this field can be set by:
 Configuring Package Preferences
 -------------------------------
 
-Package preferences in Spack are managed through the ``packages.yaml``
-configuration file. First, we will look at the default
-``packages.yaml`` file.
+Package preferences in Spack are managed through the ``packages``
+configuration section. First, we will look at the default ``packages.yaml``
+file.
 
 .. code-block:: console
 
@@ -460,11 +461,6 @@ a section name):
    produce the same output (because they weren't run with the
    configuration changes made here)
 
-
-Note that outside of an environment, the configuration sections are
-generally managed as separate files (e.g. the ``packages.yaml`` file
-stores all config related to package configuration) but in an
-environment, the sections are all stored in a single file.
 
 .. code-block:: yaml
 
@@ -675,7 +671,7 @@ forbidden it from building. We could resolve this by requesting
 ``hdf5+mpi%clang^mpich`` explicitly, or we can configure Spack not to
 use any other MPI implementation. Since we're focused on
 configurations here and the former can get tedious, we'll need to
-modify our ``packages.yaml`` file again.
+modify our ``packages`` configuration again.
 
 While we're at it, we can configure HDF5 to build with MPI by default
 again.
@@ -725,7 +721,7 @@ same spec syntax.
 Installation permissions
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``packages.yaml`` file also controls the default permissions
+The ``packages`` configuration also controls the default permissions
 to use when installing a package. You'll notice that by default,
 the installation prefix will be world-readable but only user-writable.
 

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -450,14 +450,17 @@ packages without shared libraries. We will accomplish this by turning
 off the ``shared`` variant on all packages that have one.
 
 .. code-block:: yaml
-   :emphasize-lines: 6
+   :emphasize-lines: 9
 
-   packages:
-     all:
-       compiler: [clang, gcc, intel, pgi, xl, nag]
-       providers:
-         mpi: [mpich, openmpi]
-       variants: ~shared
+   spack:
+     specs: []
+     view: true
+     packages:
+       all:
+         compiler: [clang, gcc, intel, pgi, xl, nag, fj]
+         providers:
+           mpi: [mpich, openmpi]
+         variants: ~shared
 
 
 We can check the effect of this command with ``spack spec hdf5`` again.
@@ -475,16 +478,19 @@ need serial HDF5, that might get annoying quickly, having to type
 HDF5.
 
 .. code-block:: yaml
-   :emphasize-lines: 7-8
+   :emphasize-lines: 10-11
 
-   packages:
-     all:
-       compiler: [clang, gcc, intel, pgi, xl, nag]
-       providers:
-         mpi: [mpich, openmpi]
-       variants: ~shared
-     hdf5:
-       variants: ~mpi
+   spack:
+     specs: []
+     view: true
+     packages:
+       all:
+         compiler: [clang, gcc, intel, pgi, xl, nag, fj]
+         providers:
+           mpi: [mpich, openmpi]
+         variants: ~shared
+       hdf5:
+         variants: ~mpi
 
 
 Now hdf5 will concretize without an MPI dependency by default.
@@ -512,19 +518,23 @@ On these systems we have a pre-installed zlib. Let's tell Spack about
 this package and where it can be found:
 
 .. code-block:: yaml
-   :emphasize-lines: 9-11
+   :emphasize-lines: 12-15
 
-   packages:
-     all:
-       compiler: [clang, gcc, intel, pgi, xl, nag]
-       providers:
-         mpi: [mpich, openmpi]
-       variants: ~shared
-     hdf5:
-       variants: ~mpi
-     zlib:
-       paths:
-         zlib@1.2.8%gcc@7.5.0: /usr
+   spack:
+     specs: []
+     view: true
+     packages:
+       all:
+         compiler: [clang, gcc, intel, pgi, xl, nag, fj]
+         providers:
+           mpi: [mpich, openmpi]
+         variants: ~shared
+       hdf5:
+         variants: ~mpi
+       zlib:
+         externals:
+         - spec: zlib@1.2.8%gcc@7.5.0
+           prefix: /usr
 
 
 Here, we've told Spack that zlib 1.2.8 is installed on our system.
@@ -552,18 +562,22 @@ not allowed to build its own zlib. We'll go with the latter.
 .. code-block:: yaml
    :emphasize-lines: 12
 
-   packages:
-     all:
-       compiler: [clang, gcc, intel, pgi, xl, nag]
-       providers:
-         mpi: [mpich, openmpi]
-       variants: ~shared
-     hdf5:
-       variants: ~mpi
-     zlib:
-       paths:
-         zlib@1.2.8%gcc@7.5.0: /usr
-       buildable: false
+   spack:
+     specs: []
+     view: true
+     packages:
+       all:
+         compiler: [clang, gcc, intel, pgi, xl, nag, fj]
+         providers:
+           mpi: [mpich, openmpi]
+         variants: ~shared
+       hdf5:
+         variants: ~mpi
+       zlib:
+         externals:
+         - spec: zlib@1.2.8%gcc@7.5.0
+           prefix: /usr
+         buildable: false
 
 
 Now Spack will be forced to choose the external zlib.
@@ -577,24 +591,29 @@ we don't want to build our own MPI, but we now want a parallel version
 of HDF5. Well, fortunately we have MPICH installed on these systems.
 
 .. code-block:: yaml
-   :emphasize-lines: 13-16
+   :emphasize-lines: 17-21
 
-   packages:
-     all:
-       compiler: [clang, gcc, intel, pgi, xl, nag]
-       providers:
-         mpi: [mpich, openmpi]
-       variants: ~shared
-     hdf5:
-       variants: ~mpi
-     zlib:
-       paths:
-         zlib@1.2.8%gcc@7.5.0: /usr
-       buildable: false
-     mpich:
-       paths:
-         mpich@3.3%gcc@7.5.0: /usr
-       buildable: false
+   spack:
+     specs: []
+     view: true
+     packages:
+       all:
+         compiler: [clang, gcc, intel, pgi, xl, nag, fj]
+         providers:
+           mpi: [mpich, openmpi]
+         variants: ~shared
+       hdf5:
+         variants: ~mpi
+       zlib:
+         externals:
+         - spec: zlib@1.2.8%gcc@7.5.0
+           prefix: /usr
+         buildable: false
+       mpich:
+         externals:
+         - spec: mpich@3.3%gcc@7.5.0
+           prefix: /usr
+         buildable: false
 
 
 If we concretize ``hdf5+mpi`` with this configuration file, we will just
@@ -616,23 +635,28 @@ While we're at it, we can configure HDF5 to build with MPI by default
 again.
 
 .. code-block:: yaml
-   :emphasize-lines: 14-15
+   :emphasize-lines: 19-20
 
-   packages:
-     all:
-       compiler: [clang, gcc, intel, pgi, xl, nag]
-       providers:
-         mpi: [mpich, openmpi]
-       variants: ~shared
-     zlib:
-       paths:
-         zlib@1.2.8%gcc@7.5.0: /usr
-       buildable: false
-     mpich:
-       paths:
-         mpich@3.3%gcc@7.5.0: /usr
-     mpi:
-       buildable: False
+   spack:
+     specs: []
+     view: true
+     packages:
+       all:
+         compiler: [clang, gcc, intel, pgi, xl, nag, fj]
+         providers:
+           mpi: [mpich, openmpi]
+         variants: ~shared
+       zlib:
+         externals:
+         - spec: zlib@1.2.8%gcc@7.5.0
+           prefix: /usr
+         buildable: false
+       mpich:
+         externals:
+         - spec: mpich@3.3%gcc@7.5.0
+           prefix: /usr
+       mpi:
+         buildable: false
 
 
 Now that we have configured Spack not to build any possible provider

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -108,9 +108,13 @@ These files are listed in decreasing order of precedence, so files in
 YAML Format
 -----------
 
-Spack configurations are YAML dictionaries. Every configuration file
-begins with a top-level dictionary that tells Spack which
-configuration set it modifies. When Spack checks its configuration,
+Spack configurations are nested YAML dictionaries with a specified
+schema. The configuration is organized into sections based on theme
+(e.g. a 'compilers' section) and the highest-level keys of the dictionary
+specify the section. Spack generally maintains a separate file for
+each section (although environments keep them together).
+
+When Spack checks its configuration,
 the configuration scopes are updated as dictionaries in increasing
 order of precedence, allowing higher precedence files to override
 lower. YAML dictionaries use a colon ":" to specify key-value

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -45,6 +45,7 @@ in order of decreasing priority, are:
 Scope          Directory
 ============   ===================================================
 Command-line   N/A
+Environment    In environment base directory (in ``spack.yaml``)
 Custom         Custom directory, specified with ``--config-scope``
 User           ``~/.spack/``
 Site           ``$SPACK_ROOT/etc/spack/``
@@ -402,21 +403,33 @@ MPICH over OpenMPI. Currently, we prefer GCC and OpenMPI.
    :emphasize-lines: 9
 
 
-Now we will open the packages configuration file and update our
-preferences.
+Let's override these default preferences in an environment. When you
+have an activated environment, you can edit the associated
+configuration with ``spack config edit`` (you don't have to provide
+a section name):
 
 .. code-block:: console
 
-   $ spack config edit packages
+   $ spack env create config-env
+   $ spack env activate config-env
+   $ spack config edit
 
+
+Note that outside of an environment, the configuration sections are
+generally managed as separate files (e.g. the ``packages.yaml`` file
+stores all config related to package configuration) but in an
+environment, the sections are all stored in a single file.
 
 .. code-block:: yaml
 
-   packages:
-     all:
-       compiler: [clang, gcc, intel, pgi, xl, nag, fj]
-       providers:
-         mpi: [mpich, openmpi]
+   spack:
+     specs: []
+     view: true
+     packages:
+       all:
+         compiler: [clang, gcc, intel, pgi, xl, nag, fj]
+         providers:
+           mpi: [mpich, openmpi]
 
 
 Because of the configuration scoping we discussed earlier, this

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -471,7 +471,7 @@ We can check the effect of this command with ``spack spec hdf5`` again.
 
 .. literalinclude:: outputs/config/2.prefs.out
    :language: console
-   :emphasize-lines: 8,13,22,28
+   :emphasize-lines: 8,13,23,29
 
 
 So far we have only made global changes to the package preferences. As

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -112,7 +112,8 @@ Spack configurations are nested YAML dictionaries with a specified
 schema. The configuration is organized into sections based on theme
 (e.g. a 'compilers' section) and the highest-level keys of the dictionary
 specify the section. Spack generally maintains a separate file for
-each section (although environments keep them together).
+each section, although environments keep them together (in
+``spack.yaml``).
 
 When Spack checks its configuration,
 the configuration scopes are updated as dictionaries in increasing
@@ -149,6 +150,33 @@ configuration file had a single colon instead of the double colon, it
 would add the GCC version 7.5.0 compiler to whatever other compilers
 were listed in other configuration files.
 
+The schema for a section applies whether that section is an individual
+file or part of an environment, except that the sections are nested 1
+level underneath the top-level 'spack' key in an environment's
+``spack.yaml`` file. For example the above ``compilers.yaml`` could be
+incorporated into an environment's ``spack.yaml`` like so:
+
+.. code-block:: yaml
+
+   spack:
+     specs: []
+     view: true
+     compilers::
+     - compiler:
+         spec: gcc@7.5.0
+         paths:
+           cc: /usr/bin/gcc
+           cxx: /usr/bin/g++
+           f77: /usr/bin/gfortran
+           fc: /usr/bin/gfortran
+         flags: {}
+         operating_system: ubuntu18.04
+         target: x86_64
+         modules: []
+         environment: {}
+         extra_rpaths: []
+
+
 .. _configs-tutorial-compilers:
 
 ----------------------
@@ -169,6 +197,10 @@ We will start by opening the compilers configuration file:
 
    $ spack config edit compilers
 
+
+We start with no active environment, so this will open a
+``compilers.yaml`` file for editing (you can also do this with an
+active environment):
 
 .. code-block:: yaml
 
@@ -417,6 +449,16 @@ a section name):
    $ spack env create config-env
    $ spack env activate config-env
    $ spack config edit
+
+
+.. warning::
+
+   You will get exactly the same effects if you make these changes
+   without using an environment, but you must delete the
+   associated ``packages.yaml`` file after the config tutorial or
+   the commands you run in later tutorial sections will not
+   produce the same output (because they weren't run with the
+   configuration changes made here)
 
 
 Note that outside of an environment, the configuration sections are
@@ -704,10 +746,19 @@ the software. We can do this like so:
 Now, only members of the ``fluid_dynamics`` group can use any
 ``converge`` installations.
 
+At this point we want to discard the configuration changes we made
+in this tutorial section, so we can deactivate the environment:
+
+.. code-block:: console
+
+   $ spack env deactivate
+
+
 .. warning::
 
-   You should now ``spack env deactivate`` to avoid changing how
-   specs in later tutorial sections are concretized.
+   If you do not deactivate the ``config-env`` environment, then
+   specs will be concretized differently in later tutorial sections
+   and your results will not match.
 
 
 -----------------
@@ -715,9 +766,9 @@ High-level Config
 -----------------
 
 In addition to compiler and package settings, Spack allows customization
-of several high-level settings. These settings are stored in the generic
-``config.yaml`` configuration file. You can see the default settings by
-running:
+of several high-level settings. These settings are managed in the ``config``
+section (in ``config.yaml`` when stored as an individual file outside of
+an environment). You can see the default settings by running:
 
 .. code-block:: console
 


### PR DESCRIPTION
Fixes https://github.com/spack/spack-tutorial/issues/89

* All modifications to `packages` config are now done within an environment. 
  * This is expected to address #89 because there is no confusion about the location of `packages.yaml`, deactivating the environment is sufficient to undo the config changes
* Specification of externals was based on `v0.15`. Externals are now (as of `v0.16.1`) specified differently and the tutorial is likewise updated to reflect that.
* The environment scope is now included in the scope prioritization table

Other notes:

* compilers/high-level config tutorial sections are still done outside of an environment

TODOs

- [x] I want to add a mention somewhere of how configuration is loosely organized (I don't think the tutorial explicitly mentions for example that we put all compiler-related config into its own YAML section)