### PR TITLE
environments: move environments tutorial to be *before* configuration

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -56,10 +56,10 @@ following methods to run through the scripts:
 You should now be ready to run through our demo scripts:
 
   #. :ref:`basics-tutorial`
+  #. :ref:`environments-tutorial`
   #. :ref:`configs-tutorial`
   #. :ref:`packaging-tutorial`
   #. :ref:`developer-workflows-tutorial`
-  #. :ref:`environments-tutorial`
   #. :ref:`stacks-tutorial`
   #. :ref:`modules-tutorial`
   #. :ref:`build-systems-tutorial`

--- a/index.rst
+++ b/index.rst
@@ -79,10 +79,10 @@ Full contents:
    :caption: Tutorial
 
    tutorial_basics
+   tutorial_environments
    tutorial_configuration
    tutorial_packaging
    tutorial_developer_workflows
-   tutorial_environments
    tutorial_stacks
    tutorial_modules
    tutorial_buildsystems

--- a/outputs/Makefile
+++ b/outputs/Makefile
@@ -1,7 +1,9 @@
 .PHONY: all replay
 
+# name of the container we'll generate the tutorial outputs with
+container = spack/tutorial:ecp21-validation
 raw_output = raw/*/*.out
-subdirs = basics packaging environments stacks dev scripting
+subdirs = basics environments packaging environments stacks dev scripting
 
 all:
 	echo "Filtering raw outputs though col"
@@ -17,10 +19,10 @@ all:
 run:
 	docker run --rm -it \
 		--mount type=bind,source=${PWD},target=/project \
-		spack/tutorial:ecp21-validation \
+		${container} \
 		/project/basics.sh
 
 interactive:
 	docker run --rm -it \
 		--mount type=bind,source=${PWD},target=/project \
-		spack/tutorial:ecp21-validation
+		${container}

--- a/outputs/basics.sh
+++ b/outputs/basics.sh
@@ -15,7 +15,7 @@ example basics/clone         "git clone https://github.com/spack/spack ~/spack"
 
 example basics/checkout      "cd ~/spack"
 cd ~/spack
-example basics/checkout      "git checkout releases/v0.16"
+example basics/checkout      "git checkout ${tutorial_branch}"
 
 example basics/source-setup  ". share/spack/setup-env.sh"
 

--- a/outputs/defs.sh
+++ b/outputs/defs.sh
@@ -10,6 +10,9 @@ fi
 
 raw_outputs="${PROJECT}/raw"
 
+# used by scripts
+tutorial_branch=releases/v0.16
+
 example() {
     if [[ "$1" == "-tee" ]]; then
         # tee option allows us to use bash function; only use when necessary

--- a/outputs/env.sh
+++ b/outputs/env.sh
@@ -74,7 +74,7 @@ spack config add packages:all:providers:mpi:[mpich]
 
 example environments/spec-2          "spack spec hypre"
 
-example environments/concretize-f-1 "spack concretize -f"
+example environments/concretize-f-1 "spack concretize --force"
 
 example environments/show-mpicc-1    "spack env status"
 example environments/show-mpicc-1    "which mpicc"

--- a/outputs/environments/add-1.out
+++ b/outputs/environments/add-1.out
@@ -9,12 +9,14 @@ $ spack find
 ==> Root specs
 gmp   hdf5 +hl	tcl   trilinos
 
-==> 37 installed packages
+==> 41 installed packages
 -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-autoconf@2.69	 glm@0.9.7.1	      libtool@2.4.6   netcdf-c@4.7.3	      perl@5.30.3	  xz@5.2.5
-automake@1.16.2  hdf5@1.10.6	      libxml2@2.9.10  netlib-scalapack@2.1.0  pkgconf@1.7.3	  zlib@1.2.11
-boost@1.73.0	 hwloc@1.11.11	      m4@1.4.18       numactl@2.0.12	      readline@8.0
-bzip2@1.0.8	 hypre@2.18.2	      matio@1.5.13    openblas@0.3.10	      suite-sparse@5.7.2
-cmake@3.17.3	 libiconv@1.16	      metis@5.1.0     openmpi@3.1.6	      tcl@8.6.8
-diffutils@3.7	 libpciaccess@0.13.5  mumps@5.3.3     openssl@1.1.1g	      trilinos@12.18.1
-gdbm@1.18.1	 libsigsegv@2.12      ncurses@6.2     parmetis@4.0.3	      util-macros@1.19.1
+autoconf@2.69		     glm@0.9.7.1	libxml2@2.9.10		numactl@2.0.14	    tcl@8.6.10
+autoconf-archive@2019.01.06  gmp@6.1.2		m4@1.4.18		openblas@0.3.12     trilinos@13.0.1
+automake@1.16.2 	     hdf5@1.10.7	matio@1.5.17		openmpi@3.1.6	    util-macros@1.19.1
+berkeley-db@18.1.40	     hwloc@1.11.11	metis@5.1.0		openssl@1.1.1h	    xz@5.2.5
+boost@1.74.0		     hypre@2.20.0	mpfr@4.0.2		parmetis@4.0.3	    zlib@1.2.11
+bzip2@1.0.8		     libiconv@1.16	mumps@5.3.3		perl@5.32.0
+cmake@3.18.4		     libpciaccess@0.16	ncurses@6.2		pkgconf@1.7.3
+diffutils@3.7		     libsigsegv@2.12	netcdf-c@4.7.4		readline@8.0
+gdbm@1.18.1		     libtool@2.4.6	netlib-scalapack@2.1.0	suite-sparse@5.8.1

--- a/outputs/environments/add-2.out
+++ b/outputs/environments/add-2.out
@@ -1,38 +1,41 @@
 $ spack install
 ==> Concretized hdf5+hl
-[+]  7r2lztq  hdf5@1.10.6%gcc@7.5.0~cxx~debug~fortran+hl+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
-[+]  wudo6ky	  ^openmpi@3.1.6%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~memchecker~pmi~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
-[+]  ckxpgsn	      ^hwloc@1.11.11%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
-[+]  cmn6yii		  ^libpciaccess@0.13.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  ejanivx  hdf5@1.10.7%gcc@7.5.0~cxx~debug~fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+[+]  pmsyupw	  ^openmpi@3.1.6%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
+[+]  zqwfzhw	      ^hwloc@1.11.11%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
+[+]  bob4o5m		  ^libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  jdxbjft		      ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  mkc3u4x			  ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
 [+]  lbrx7ln			      ^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  4sh6pym		      ^pkgconf@1.7.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  gs6ag7k		      ^util-macros@1.19.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  m3l53bh		  ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
+[+]  yn2r3wf		  ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
 [+]  jearpk4		      ^libiconv@1.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  6nxes4r		      ^xz@5.2.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  komekkm		      ^xz@5.2.5%gcc@7.5.0~pic arch=linux-ubuntu18.04-x86_64
 [+]  smoyzzo		      ^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64
-[+]  yvxocdy		  ^numactl@2.0.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  nwb3bf5		      ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  hyrsxn4			  ^perl@5.30.3%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  wbqbc5v		  ^numactl@2.0.14%gcc@7.5.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94 arch=linux-ubuntu18.04-x86_64
+[+]  mm33a3o		      ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  zfdvt2j			  ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  4ihuiaz			      ^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  4av4gyw			      ^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  t54jzdy				  ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  crhlefo				      ^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-x86_64
-[+]  wdflovn		      ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  d2krmb5		      ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 
 ==> Concretized gmp
 [+]  3ol3tld  gmp@6.1.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  nwb3bf5	  ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  mm33a3o	  ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  mkc3u4x	      ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
 [+]  lbrx7ln		  ^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  hyrsxn4	      ^perl@5.30.3%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  zfdvt2j	      ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  4ihuiaz		  ^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  4av4gyw		  ^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  t54jzdy		      ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  crhlefo			  ^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-x86_64
 [+]  4sh6pym			      ^pkgconf@1.7.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  wdflovn	  ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  d2krmb5	  ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  jdxbjft	  ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 
 ==> Installing environment myproject
+==> All of the packages are already installed
 ==> Updating view at /home/spack/spack/var/spack/environments/myproject/.spack-env/view

--- a/outputs/environments/add-3.out
+++ b/outputs/environments/add-3.out
@@ -3,13 +3,14 @@ $ spack find
 ==> Root specs
 gmp   hdf5 +hl	tcl   trilinos
 
-==> 38 installed packages
+==> 41 installed packages
 -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-autoconf@2.69	 gmp@6.1.2	      libxml2@2.9.10	      numactl@2.0.12   suite-sparse@5.7.2
-automake@1.16.2  hdf5@1.10.6	      m4@1.4.18 	      openblas@0.3.10  tcl@8.6.8
-boost@1.73.0	 hwloc@1.11.11	      matio@1.5.13	      openmpi@3.1.6    trilinos@12.18.1
-bzip2@1.0.8	 hypre@2.18.2	      metis@5.1.0	      openssl@1.1.1g   util-macros@1.19.1
-cmake@3.17.3	 libiconv@1.16	      mumps@5.3.3	      parmetis@4.0.3   xz@5.2.5
-diffutils@3.7	 libpciaccess@0.13.5  ncurses@6.2	      perl@5.30.3      zlib@1.2.11
-gdbm@1.18.1	 libsigsegv@2.12      netcdf-c@4.7.3	      pkgconf@1.7.3
-glm@0.9.7.1	 libtool@2.4.6	      netlib-scalapack@2.1.0  readline@8.0
+autoconf@2.69		     glm@0.9.7.1	libxml2@2.9.10		numactl@2.0.14	    tcl@8.6.10
+autoconf-archive@2019.01.06  gmp@6.1.2		m4@1.4.18		openblas@0.3.12     trilinos@13.0.1
+automake@1.16.2 	     hdf5@1.10.7	matio@1.5.17		openmpi@3.1.6	    util-macros@1.19.1
+berkeley-db@18.1.40	     hwloc@1.11.11	metis@5.1.0		openssl@1.1.1h	    xz@5.2.5
+boost@1.74.0		     hypre@2.20.0	mpfr@4.0.2		parmetis@4.0.3	    zlib@1.2.11
+bzip2@1.0.8		     libiconv@1.16	mumps@5.3.3		perl@5.32.0
+cmake@3.18.4		     libpciaccess@0.16	ncurses@6.2		pkgconf@1.7.3
+diffutils@3.7		     libsigsegv@2.12	netcdf-c@4.7.4		readline@8.0
+gdbm@1.18.1		     libtool@2.4.6	netlib-scalapack@2.1.0	suite-sparse@5.8.1

--- a/outputs/environments/add-anonymous-1.out
+++ b/outputs/environments/add-anonymous-1.out
@@ -2,12 +2,12 @@ $ spack add hdf5@5.5.1
 ==> Adding hdf5@5.5.1 to environment /home/spack/code
 ==> Updating view at /home/spack/code/.spack-env/view
 $ cat spack.yaml
-# This is a Spack Environment file.
-#
-# It describes a set of packages to be installed, along with
-# configuration settings.
+  This is a Spack Environment file.
+ 
+  It describes a set of packages to be installed, along with
+  configuration settings.
 spack:
-  # add package specs to the `specs` list
+    add package specs to the `specs` list
   specs: [boost, trilinos, openmpi, hdf5@5.5.1]
   view: true
 $ spack remove hdf5

--- a/outputs/environments/add-anonymous-1.out
+++ b/outputs/environments/add-anonymous-1.out
@@ -2,12 +2,12 @@ $ spack add hdf5@5.5.1
 ==> Adding hdf5@5.5.1 to environment /home/spack/code
 ==> Updating view at /home/spack/code/.spack-env/view
 $ cat spack.yaml
-  This is a Spack Environment file.
- 
-  It describes a set of packages to be installed, along with
-  configuration settings.
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
 spack:
-    add package specs to the `specs` list
+  # add package specs to the `specs` list
   specs: [boost, trilinos, openmpi, hdf5@5.5.1]
   view: true
 $ spack remove hdf5

--- a/outputs/environments/anonymous-create-2.out
+++ b/outputs/environments/anonymous-create-2.out
@@ -1,11 +1,11 @@
 $ ls
 spack.yaml
 $ cat spack.yaml
-# This is a Spack Environment file.
-#
-# It describes a set of packages to be installed, along with
-# configuration settings.
+  This is a Spack Environment file.
+ 
+  It describes a set of packages to be installed, along with
+  configuration settings.
 spack:
-  # add package specs to the `specs` list
+    add package specs to the `specs` list
   specs: []
   view: true

--- a/outputs/environments/anonymous-create-2.out
+++ b/outputs/environments/anonymous-create-2.out
@@ -1,11 +1,11 @@
 $ ls
 spack.yaml
 $ cat spack.yaml
-  This is a Spack Environment file.
- 
-  It describes a set of packages to be installed, along with
-  configuration settings.
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
 spack:
-    add package specs to the `specs` list
+  # add package specs to the `specs` list
   specs: []
   view: true

--- a/outputs/environments/concretize-f-1.out
+++ b/outputs/environments/concretize-f-1.out
@@ -1,81 +1,87 @@
-$ spack concretize -f
+$ spack concretize --force
 ==> Concretized tcl
-[+]  aszidzn  tcl@8.6.8%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  rtz7664  tcl@8.6.10%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  smoyzzo	  ^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64
 
 ==> Concretized trilinos
-[+]  rhmspsu  trilinos@12.18.1%gcc@7.5.0~adios2~alloptpkgs+amesos+amesos2+anasazi+aztec+belos+boost~cgns~chaco~complex~debug~dtk+epetra+epetraext+exodus+explicit_template_instantiation~float+fortran~fortrilinos+glm+gtest+hdf5+hypre+ifpack+ifpack2~intrepid~intrepid2~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~shards+shared~shylu~stk~stratimikos+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo gotype=long arch=linux-ubuntu18.04-x86_64
-[+]  qzr23mk	  ^boost@1.73.0%gcc@7.5.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=246508e052c44b6f4e8c2542a71c06cacaa72cd1447ab8d2a542b987bc35ace9,4dd507e1f5a29e3b87b15321a4d8c74afdc8331433edabf7aeab89b3c405d556 visibility=hidden arch=linux-ubuntu18.04-x86_64
+[+]  xvzpvxd  trilinos@13.0.1%gcc@7.5.0~adios2~alloptpkgs+amesos+amesos2+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~debug~dtk+epetra+epetraext+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~shards+shared~shylu~stk~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long arch=linux-ubuntu18.04-x86_64
+[+]  hc5atqc	  ^boost@1.74.0%gcc@7.5.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden arch=linux-ubuntu18.04-x86_64
 [+]  fvfpt26	      ^bzip2@1.0.8%gcc@7.5.0+shared arch=linux-ubuntu18.04-x86_64
 [+]  otkkten		  ^diffutils@3.7%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  jearpk4		      ^libiconv@1.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  smoyzzo	      ^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64
-[+]  thpwgui	  ^cmake@3.17.3%gcc@7.5.0~doc+ncurses+openssl+ownlibs~qt arch=linux-ubuntu18.04-x86_64
+[+]  bltycqw	  ^cmake@3.18.4%gcc@7.5.0~doc+ncurses+openssl+ownlibs~qt patches=bf695e3febb222da2ed94b3beea600650e4318975da90e4a71d6f31a6d5d8c3d arch=linux-ubuntu18.04-x86_64
 [+]  crhlefo	      ^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-x86_64
 [+]  4sh6pym		  ^pkgconf@1.7.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  4dj34yw	      ^openssl@1.1.1g%gcc@7.5.0+systemcerts arch=linux-ubuntu18.04-x86_64
-[+]  hyrsxn4		  ^perl@5.30.3%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  es377uq	      ^openssl@1.1.1h%gcc@7.5.0+systemcerts arch=linux-ubuntu18.04-x86_64
+[+]  zfdvt2j		  ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  4ihuiaz		      ^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  4av4gyw		      ^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  t54jzdy			  ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  c3mfw24	  ^glm@0.9.7.1%gcc@7.5.0 build_type=RelWithDebInfo arch=linux-ubuntu18.04-x86_64
-[+]  znt7mfz	  ^hdf5@1.10.6%gcc@7.5.0~cxx~debug~fortran+hl+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
-[+]  qrpxybc	      ^mpich@3.3.2%gcc@7.5.0+hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
-[+]  nwb3bf5		  ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  n4xti2g	  ^glm@0.9.7.1%gcc@7.5.0~ipo build_type=RelWithDebInfo arch=linux-ubuntu18.04-x86_64
+[+]  cq4k4cv	  ^hdf5@1.10.7%gcc@7.5.0~cxx~debug~fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+[+]  vbelg5s	      ^mpich@3.3.2%gcc@7.5.0~argobots+fortran+hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
+[+]  mm33a3o		  ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  mkc3u4x		      ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
 [+]  lbrx7ln			  ^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  wdflovn		  ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  d2krmb5		  ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  hrv4dx5		  ^findutils@4.6.0%gcc@7.5.0 patches=84b916c0bf8c51b7e7b28417692f0ad3e7030d1f3c248ba77c42ede5c1c5d11e,bd9e4e5cc280f9753ae14956c4e4aa17fe7a210f55dd6c84aa60b12d106d47a2 arch=linux-ubuntu18.04-x86_64
 [+]  jdxbjft		      ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  cr3i7es		      ^texinfo@6.5%gcc@7.5.0 patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1 arch=linux-ubuntu18.04-x86_64
-[+]  luexnup		  ^hwloc@2.2.0%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
-[+]  cmn6yii		      ^libpciaccess@0.13.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  p46ba5q		      ^texinfo@6.5%gcc@7.5.0 patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1 arch=linux-ubuntu18.04-x86_64
+[+]  a4cxlu7		  ^hwloc@2.2.0%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
+[+]  bob4o5m		      ^libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  gs6ag7k			  ^util-macros@1.19.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  m3l53bh		      ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
-[+]  6nxes4r			  ^xz@5.2.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  amfr6qp	  ^hypre@2.18.2%gcc@7.5.0~complex~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist arch=linux-ubuntu18.04-x86_64
-[+]  m5gktgo	      ^openblas@0.3.10%gcc@7.5.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-x86_64
-[+]  w6s7lu2	  ^matio@1.5.13%gcc@7.5.0+hdf5+shared+zlib arch=linux-ubuntu18.04-x86_64
+[+]  yn2r3wf		      ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
+[+]  komekkm			  ^xz@5.2.5%gcc@7.5.0~pic arch=linux-ubuntu18.04-x86_64
+[+]  us6giii	  ^hypre@2.20.0%gcc@7.5.0~complex~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059 arch=linux-ubuntu18.04-x86_64
+[+]  te35tjx	      ^openblas@0.3.12%gcc@7.5.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-x86_64
+[+]  usmrkqu	  ^matio@1.5.17%gcc@7.5.0+hdf5+shared+zlib arch=linux-ubuntu18.04-x86_64
 [+]  edcrft4	  ^metis@5.1.0%gcc@7.5.0~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2 arch=linux-ubuntu18.04-x86_64
-[+]  hbvf64o	  ^mumps@5.3.3%gcc@7.5.0+complex+double+float~int64~metis+mpi~parmetis~ptscotch~scotch+shared arch=linux-ubuntu18.04-x86_64
-[+]  i6dfzly	      ^netlib-scalapack@2.1.0%gcc@7.5.0~pic+shared build_type=RelWithDebInfo patches=f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2 arch=linux-ubuntu18.04-x86_64
-[+]  swympwh	  ^netcdf-c@4.7.3%gcc@7.5.0~dap~hdf4~jna+mpi~parallel-netcdf+pic+shared arch=linux-ubuntu18.04-x86_64
-[+]  v42khiu	  ^parmetis@4.0.3%gcc@7.5.0~gdb+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d arch=linux-ubuntu18.04-x86_64
-[+]  dgppz4n	  ^suite-sparse@5.7.2%gcc@7.5.0~cuda~openmp+pic~tbb arch=linux-ubuntu18.04-x86_64
+[+]  rmlof2f	  ^mumps@5.3.3%gcc@7.5.0+complex+double+float~int64~metis+mpi~parmetis~ptscotch~scotch+shared arch=linux-ubuntu18.04-x86_64
+[+]  h7suxc3	      ^netlib-scalapack@2.1.0%gcc@7.5.0~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2 arch=linux-ubuntu18.04-x86_64
+[+]  spkgtxp	  ^netcdf-c@4.7.4%gcc@7.5.0~dap~hdf4~jna+mpi~parallel-netcdf+pic+shared arch=linux-ubuntu18.04-x86_64
+[+]  i7otoak	  ^parmetis@4.0.3%gcc@7.5.0~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d arch=linux-ubuntu18.04-x86_64
+[+]  rdfmg5b	  ^suite-sparse@5.8.1%gcc@7.5.0~cuda~openmp+pic~tbb arch=linux-ubuntu18.04-x86_64
+[+]  3ol3tld	      ^gmp@6.1.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  mpv2v7v	      ^mpfr@4.0.2%gcc@7.5.0 patches=3f80b836948aa96f8d1cb9cc7f3f55973f19285482a96f9a4e1623d460bcccf0 arch=linux-ubuntu18.04-x86_64
+[+]  bdyarrk		  ^autoconf-archive@2019.01.06%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 
 ==> Concretized hdf5+hl
-[+]  znt7mfz  hdf5@1.10.6%gcc@7.5.0~cxx~debug~fortran+hl+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
-[+]  qrpxybc	  ^mpich@3.3.2%gcc@7.5.0+hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
-[+]  nwb3bf5	      ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  cq4k4cv  hdf5@1.10.7%gcc@7.5.0~cxx~debug~fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+[+]  vbelg5s	  ^mpich@3.3.2%gcc@7.5.0~argobots+fortran+hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
+[+]  mm33a3o	      ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  mkc3u4x		  ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
 [+]  lbrx7ln		      ^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  hyrsxn4		  ^perl@5.30.3%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  zfdvt2j		  ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  4ihuiaz		      ^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  4av4gyw		      ^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  t54jzdy			  ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  crhlefo			      ^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-x86_64
 [+]  4sh6pym				  ^pkgconf@1.7.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  wdflovn	      ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  d2krmb5	      ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  hrv4dx5	      ^findutils@4.6.0%gcc@7.5.0 patches=84b916c0bf8c51b7e7b28417692f0ad3e7030d1f3c248ba77c42ede5c1c5d11e,bd9e4e5cc280f9753ae14956c4e4aa17fe7a210f55dd6c84aa60b12d106d47a2 arch=linux-ubuntu18.04-x86_64
 [+]  jdxbjft		  ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  cr3i7es		  ^texinfo@6.5%gcc@7.5.0 patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1 arch=linux-ubuntu18.04-x86_64
-[+]  luexnup	      ^hwloc@2.2.0%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
-[+]  cmn6yii		  ^libpciaccess@0.13.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  p46ba5q		  ^texinfo@6.5%gcc@7.5.0 patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1 arch=linux-ubuntu18.04-x86_64
+[+]  a4cxlu7	      ^hwloc@2.2.0%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
+[+]  bob4o5m		  ^libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  gs6ag7k		      ^util-macros@1.19.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  m3l53bh		  ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
+[+]  yn2r3wf		  ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
 [+]  jearpk4		      ^libiconv@1.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  6nxes4r		      ^xz@5.2.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  komekkm		      ^xz@5.2.5%gcc@7.5.0~pic arch=linux-ubuntu18.04-x86_64
 [+]  smoyzzo		      ^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64
 
 ==> Concretized gmp
 [+]  3ol3tld  gmp@6.1.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  nwb3bf5	  ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  mm33a3o	  ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  mkc3u4x	      ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
 [+]  lbrx7ln		  ^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  hyrsxn4	      ^perl@5.30.3%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  zfdvt2j	      ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  4ihuiaz		  ^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  4av4gyw		  ^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  t54jzdy		      ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  crhlefo			  ^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-x86_64
 [+]  4sh6pym			      ^pkgconf@1.7.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  wdflovn	  ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  d2krmb5	  ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  jdxbjft	  ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 
 ==> Updating view at /home/spack/spack/var/spack/environments/myproject/.spack-env/view

--- a/outputs/environments/config-get-1.out
+++ b/outputs/environments/config-get-1.out
@@ -1,10 +1,9 @@
 $ spack config get
-  This is a Spack Environment file.
- 
-  It describes a set of packages to be installed, along with
-  configuration settings.
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
 spack:
-    add package specs to the `specs` list
+  # add package specs to the `specs` list
   specs: [tcl, trilinos, hdf5+hl, gmp]
   view: true
-

--- a/outputs/environments/config-get-1.out
+++ b/outputs/environments/config-get-1.out
@@ -1,10 +1,10 @@
 $ spack config get
-# This is a Spack Environment file.
-#
-# It describes a set of packages to be installed, along with
-# configuration settings.
+  This is a Spack Environment file.
+ 
+  It describes a set of packages to be installed, along with
+  configuration settings.
 spack:
-  # add package specs to the `specs` list
+    add package specs to the `specs` list
   specs: [tcl, trilinos, hdf5+hl, gmp]
   view: true
 

--- a/outputs/environments/env-create-2.out
+++ b/outputs/environments/env-create-2.out
@@ -5,75 +5,21 @@ $ spack env create myproject2
 ==>   spack env activate myproject2
 $ spack env activate myproject2
 $ spack install hdf5+hl
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libsigsegv-2.12-lbrx7lnfz46ukewxbhxnucmx76g23c6q
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/pkgconf-1.7.3-4sh6pymrm2ms4auu3ajbjjr6fiuhz5g7
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/util-macros-1.19.1-gs6ag7ktdoiirb62t7bcagjw62szrrg2
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16-jearpk4xci4zc7dkrza4fufaqfkq7rfl
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/xz-5.2.5-6nxes4rhk52rhxj7dntwqa5nzou5sv2t
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11-smoyzzo2qhzpn6mg6rd3l2p7b23enshg
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/m4-1.4.18-mkc3u4x2p2wie6jfhuku7g5rkovcrxps
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/ncurses-6.2-crhlefo3dv7lmsv5pf4icsy4gepkdorm
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libxml2-2.9.10-m3l53bhqaaznpmdxzs5jirieu4spdtyq
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libtool-2.4.6-jdxbjftheiotj6solpomva7dowrhlerl
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/readline-8.0-t54jzdy2jj4snltjazlm3br2urcilc6v
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libpciaccess-0.13.5-cmn6yii6vkzjrapeabvbcna3qqqx6web
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/gdbm-1.18.1-4av4gywgpaspkhy3dvbb62nulqogtzbb
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.30.3-hyrsxn4yox7dp7sywfcs7lbknj45c5pq
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/autoconf-2.69-nwb3bf5ibencr3coo5kgkxa7tjrj7yfy
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/automake-1.16.2-wdflovn6aocicngqouowxgj3pi3w7uoc
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/numactl-2.0.12-yvxocdy2kcxvvgatrrst3sqzyt7yxhgn
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hwloc-1.11.11-ckxpgsn6uuptknjsle5cagqxpbo3b7uc
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openmpi-3.1.6-wudo6kygednztgzemlnq4l7rlwrwu3zw
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.10.6-7r2lztqivzy6umgvnhihn4565whablho
-==> Updating view at /home/spack/spack/var/spack/environments/myproject2/.spack-env/view
+==> All of the packages are already installed
 $ spack install trilinos
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16-jearpk4xci4zc7dkrza4fufaqfkq7rfl
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11-smoyzzo2qhzpn6mg6rd3l2p7b23enshg
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/pkgconf-1.7.3-4sh6pymrm2ms4auu3ajbjjr6fiuhz5g7
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libsigsegv-2.12-lbrx7lnfz46ukewxbhxnucmx76g23c6q
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/util-macros-1.19.1-gs6ag7ktdoiirb62t7bcagjw62szrrg2
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/xz-5.2.5-6nxes4rhk52rhxj7dntwqa5nzou5sv2t
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openblas-0.3.10-m5gktgohkqi2znlic6cwpz5euhqdle3i
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/diffutils-3.7-otkktenrrvcaf37a7zyeytmjuwsalvtr
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/ncurses-6.2-crhlefo3dv7lmsv5pf4icsy4gepkdorm
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/m4-1.4.18-mkc3u4x2p2wie6jfhuku7g5rkovcrxps
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libxml2-2.9.10-m3l53bhqaaznpmdxzs5jirieu4spdtyq
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/bzip2-1.0.8-fvfpt26p5divvq6344vojyn64enojlui
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/readline-8.0-t54jzdy2jj4snltjazlm3br2urcilc6v
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libtool-2.4.6-jdxbjftheiotj6solpomva7dowrhlerl
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/boost-1.73.0-qzr23mk4jzlnkdfh4mrncz5lvpp67z2r
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/gdbm-1.18.1-4av4gywgpaspkhy3dvbb62nulqogtzbb
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libpciaccess-0.13.5-cmn6yii6vkzjrapeabvbcna3qqqx6web
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.30.3-hyrsxn4yox7dp7sywfcs7lbknj45c5pq
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssl-1.1.1g-4dj34ywr6ytskzutiwgjrj66sryvav2q
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/autoconf-2.69-nwb3bf5ibencr3coo5kgkxa7tjrj7yfy
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.17.3-thpwguiiywo7hewgnm76t7r6w53mt6cy
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/automake-1.16.2-wdflovn6aocicngqouowxgj3pi3w7uoc
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/glm-0.9.7.1-c3mfw24ivgvgfwwxfia3ipk5lqlxdgcd
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/metis-5.1.0-edcrft4l4szpqji2kowdkzq2ofueh3dr
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/numactl-2.0.12-yvxocdy2kcxvvgatrrst3sqzyt7yxhgn
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/suite-sparse-5.7.2-dgppz4n6wg4b42d4er5zovpefdywbuy3
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hwloc-1.11.11-ckxpgsn6uuptknjsle5cagqxpbo3b7uc
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openmpi-3.1.6-wudo6kygednztgzemlnq4l7rlwrwu3zw
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hypre-2.18.2-dnwivcw3g3kjliygwa536iyaykvjfag6
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/netlib-scalapack-2.1.0-bvapk5ozv46rizqyzb3tlra7jwxkj2ay
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/parmetis-4.0.3-zdxekoefv7fk2qpoyv6xr26622tnosli
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.10.6-7r2lztqivzy6umgvnhihn4565whablho
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/mumps-5.3.3-qb6yumyjj73wcewf4sa4wc2kc5kutswq
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/netcdf-c-4.7.3-uctbd5yydaciec4ircts7prazhmpllj5
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/matio-1.5.13-w3dbllqxjzh3xyc5hexo7jedowsixau5
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/trilinos-12.18.1-j6dav6kowb2c4sfq36vpn7vfhn7es3zf
-==> Updating view at /home/spack/spack/var/spack/environments/myproject2/.spack-env/view
+==> All of the packages are already installed
 $ spack find
 ==> In environment myproject2
 ==> Root specs
 hdf5 +hl  trilinos
 
-==> 36 installed packages
+==> 40 installed packages
 -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-autoconf@2.69	 gdbm@1.18.1	libpciaccess@0.13.5  metis@5.1.0	     openblas@0.3.10  readline@8.0
-automake@1.16.2  glm@0.9.7.1	libsigsegv@2.12      mumps@5.3.3	     openmpi@3.1.6    suite-sparse@5.7.2
-boost@1.73.0	 hdf5@1.10.6	libtool@2.4.6	     ncurses@6.2	     openssl@1.1.1g   trilinos@12.18.1
-bzip2@1.0.8	 hwloc@1.11.11	libxml2@2.9.10	     netcdf-c@4.7.3	     parmetis@4.0.3   util-macros@1.19.1
-cmake@3.17.3	 hypre@2.18.2	m4@1.4.18	     netlib-scalapack@2.1.0  perl@5.30.3      xz@5.2.5
-diffutils@3.7	 libiconv@1.16	matio@1.5.13	     numactl@2.0.12	     pkgconf@1.7.3    zlib@1.2.11
+autoconf@2.69		     gdbm@1.18.1	libsigsegv@2.12  ncurses@6.2		 perl@5.32.0
+autoconf-archive@2019.01.06  glm@0.9.7.1	libtool@2.4.6	 netcdf-c@4.7.4 	 pkgconf@1.7.3
+automake@1.16.2 	     gmp@6.1.2		libxml2@2.9.10	 netlib-scalapack@2.1.0  readline@8.0
+berkeley-db@18.1.40	     hdf5@1.10.7	m4@1.4.18	 numactl@2.0.14 	 suite-sparse@5.8.1
+boost@1.74.0		     hwloc@1.11.11	matio@1.5.17	 openblas@0.3.12	 trilinos@13.0.1
+bzip2@1.0.8		     hypre@2.20.0	metis@5.1.0	 openmpi@3.1.6		 util-macros@1.19.1
+cmake@3.18.4		     libiconv@1.16	mpfr@4.0.2	 openssl@1.1.1h 	 xz@5.2.5
+diffutils@3.7		     libpciaccess@0.16	mumps@5.3.3	 parmetis@4.0.3 	 zlib@1.2.11

--- a/outputs/environments/env-install-1.out
+++ b/outputs/environments/env-install-1.out
@@ -1,59 +1,66 @@
 $ spack env activate myproject
 $ spack install tcl
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11-smoyzzo2qhzpn6mg6rd3l2p7b23enshg
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/tcl-8.6.8-aszidznovy2kcbefk4dexwf5mlrjbbcw
-==> Updating view at /home/spack/spack/var/spack/environments/myproject/.spack-env/view
+==> All of the packages are already installed
 $ spack install trilinos
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16-jearpk4xci4zc7dkrza4fufaqfkq7rfl
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11-smoyzzo2qhzpn6mg6rd3l2p7b23enshg
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/pkgconf-1.7.3-4sh6pymrm2ms4auu3ajbjjr6fiuhz5g7
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/berkeley-db-18.1.40-4ihuiazsglf22f3pntq5hc4kyszqzexn
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libsigsegv-2.12-lbrx7lnfz46ukewxbhxnucmx76g23c6q
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/util-macros-1.19.1-gs6ag7ktdoiirb62t7bcagjw62szrrg2
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/xz-5.2.5-6nxes4rhk52rhxj7dntwqa5nzou5sv2t
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openblas-0.3.10-m5gktgohkqi2znlic6cwpz5euhqdle3i
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/xz-5.2.5-komekkmyciga3kl24edjmredhj3uyt7v
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openblas-0.3.12-te35tjxctgjpeeuk357xghoinvwf2k7u
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/autoconf-archive-2019.01.06-bdyarrkdgse5adcjr4kxqc4jns74k7yn
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/diffutils-3.7-otkktenrrvcaf37a7zyeytmjuwsalvtr
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/ncurses-6.2-crhlefo3dv7lmsv5pf4icsy4gepkdorm
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/m4-1.4.18-mkc3u4x2p2wie6jfhuku7g5rkovcrxps
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libxml2-2.9.10-m3l53bhqaaznpmdxzs5jirieu4spdtyq
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libxml2-2.9.10-yn2r3wfhiilelyulh5toteicdtxjhw7d
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/bzip2-1.0.8-fvfpt26p5divvq6344vojyn64enojlui
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/readline-8.0-t54jzdy2jj4snltjazlm3br2urcilc6v
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libtool-2.4.6-jdxbjftheiotj6solpomva7dowrhlerl
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/boost-1.73.0-qzr23mk4jzlnkdfh4mrncz5lvpp67z2r
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/boost-1.74.0-hc5atqce4emwrrkxuyfayf5k43r5cst2
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/gdbm-1.18.1-4av4gywgpaspkhy3dvbb62nulqogtzbb
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libpciaccess-0.13.5-cmn6yii6vkzjrapeabvbcna3qqqx6web
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.30.3-hyrsxn4yox7dp7sywfcs7lbknj45c5pq
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssl-1.1.1g-4dj34ywr6ytskzutiwgjrj66sryvav2q
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/autoconf-2.69-nwb3bf5ibencr3coo5kgkxa7tjrj7yfy
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.17.3-thpwguiiywo7hewgnm76t7r6w53mt6cy
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/automake-1.16.2-wdflovn6aocicngqouowxgj3pi3w7uoc
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/glm-0.9.7.1-c3mfw24ivgvgfwwxfia3ipk5lqlxdgcd
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libpciaccess-0.16-bob4o5m3uku6vtdil5imasprgy775zg7
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.32.0-zfdvt2jjuaees43ffrrtphqs2ky3o22t
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/autoconf-2.69-mm33a3ocsv3jsh2tfxc4mlab4xsurtdd
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssl-1.1.1h-es377uqsqougfc67jyg7yfjyyuukin52
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/automake-1.16.2-d2krmb5gweivlnztcymhklzsqbrpatt6
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.18.4-bltycqwh5oofai4f6o42q4uuj4w5zb3j
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/gmp-6.1.2-3ol3tldmm3oqflzrqonh6p2jmhgwsr4t
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/numactl-2.0.14-wbqbc5vw5sxzwhvu56p6x5nd5n4abrvh
 [+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/metis-5.1.0-edcrft4l4szpqji2kowdkzq2ofueh3dr
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/numactl-2.0.12-yvxocdy2kcxvvgatrrst3sqzyt7yxhgn
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/suite-sparse-5.7.2-dgppz4n6wg4b42d4er5zovpefdywbuy3
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hwloc-1.11.11-ckxpgsn6uuptknjsle5cagqxpbo3b7uc
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openmpi-3.1.6-wudo6kygednztgzemlnq4l7rlwrwu3zw
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.10.6-7r2lztqivzy6umgvnhihn4565whablho
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hypre-2.18.2-dnwivcw3g3kjliygwa536iyaykvjfag6
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/netlib-scalapack-2.1.0-bvapk5ozv46rizqyzb3tlra7jwxkj2ay
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/parmetis-4.0.3-zdxekoefv7fk2qpoyv6xr26622tnosli
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/netcdf-c-4.7.3-uctbd5yydaciec4ircts7prazhmpllj5
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/matio-1.5.13-w3dbllqxjzh3xyc5hexo7jedowsixau5
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/mumps-5.3.3-qb6yumyjj73wcewf4sa4wc2kc5kutswq
-==> Installing trilinos
-==> Extracting trilinos from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/trilinos-12.18.1-j6dav6kowb2c4sfq36vpn7vfhn7es3zf
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/glm-0.9.7.1-n4xti2gmzctc2oskcjphmruidrna4vfg
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/mpfr-4.0.2-mpv2v7v7dasis5nbrrnmci5tc2rrca2y
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hwloc-1.11.11-zqwfzhw5k2ollygh6nrjpsi7u4d4g6lu
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/suite-sparse-5.8.1-rdfmg5b5lobcgmho4yqzd7zq7wibbelk
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openmpi-3.1.6-pmsyupw6w3gql4loaor25gfumlmvkl25
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.10.7-ejanivxt2gsv2qd3so7fil7izp4m3bcd
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hypre-2.20.0-nndket2abxbsbuoocew5m643e36waxj3
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/parmetis-4.0.3-htdsyvt5yp6vl3nxbxp3627gohe7ldup
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/netlib-scalapack-2.1.0-wsiydak4jm7sms57zcu4rmzmdmgxqb5j
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/matio-1.5.17-zoqjxgkw7h3yoxbagripnd6muniihwno
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/netcdf-c-4.7.4-yixejlymvzs5aduzazrbs37hugw7sl7g
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/mumps-5.3.3-3jmjrzw7kx44fyoltswqx7uhu33zikhm
+==> Installing trilinos-13.0.1-qmjbxf2kamskoplhqlejy3esksrquni2
+==> Extracting trilinos-13.0.1-qmjbxf2kamskoplhqlejy3esksrquni2 from binary cache
+gpgconf: socketdir is '/home/spack/.gnupg'
+gpgconf:	no /run/user dir
+gpgconf:	using homedir as fallback
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/trilinos-13.0.1-qmjbxf2kamskoplhqlejy3esksrquni2
 ==> Updating view at /home/spack/spack/var/spack/environments/myproject/.spack-env/view
 $ spack find
 ==> In environment myproject
 ==> Root specs
 tcl   trilinos
 
-==> 37 installed packages
+==> 41 installed packages
 -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-autoconf@2.69	 glm@0.9.7.1	      libtool@2.4.6   netcdf-c@4.7.3	      perl@5.30.3	  xz@5.2.5
-automake@1.16.2  hdf5@1.10.6	      libxml2@2.9.10  netlib-scalapack@2.1.0  pkgconf@1.7.3	  zlib@1.2.11
-boost@1.73.0	 hwloc@1.11.11	      m4@1.4.18       numactl@2.0.12	      readline@8.0
-bzip2@1.0.8	 hypre@2.18.2	      matio@1.5.13    openblas@0.3.10	      suite-sparse@5.7.2
-cmake@3.17.3	 libiconv@1.16	      metis@5.1.0     openmpi@3.1.6	      tcl@8.6.8
-diffutils@3.7	 libpciaccess@0.13.5  mumps@5.3.3     openssl@1.1.1g	      trilinos@12.18.1
-gdbm@1.18.1	 libsigsegv@2.12      ncurses@6.2     parmetis@4.0.3	      util-macros@1.19.1
+autoconf@2.69		     glm@0.9.7.1	libxml2@2.9.10		numactl@2.0.14	    tcl@8.6.10
+autoconf-archive@2019.01.06  gmp@6.1.2		m4@1.4.18		openblas@0.3.12     trilinos@13.0.1
+automake@1.16.2 	     hdf5@1.10.7	matio@1.5.17		openmpi@3.1.6	    util-macros@1.19.1
+berkeley-db@18.1.40	     hwloc@1.11.11	metis@5.1.0		openssl@1.1.1h	    xz@5.2.5
+boost@1.74.0		     hypre@2.20.0	mpfr@4.0.2		parmetis@4.0.3	    zlib@1.2.11
+bzip2@1.0.8		     libiconv@1.16	mumps@5.3.3		perl@5.32.0
+cmake@3.18.4		     libpciaccess@0.16	ncurses@6.2		pkgconf@1.7.3
+diffutils@3.7		     libsigsegv@2.12	netcdf-c@4.7.4		readline@8.0
+gdbm@1.18.1		     libtool@2.4.6	netlib-scalapack@2.1.0	suite-sparse@5.8.1

--- a/outputs/environments/env-status-2.out
+++ b/outputs/environments/env-status-2.out
@@ -1,23 +1,22 @@
-$ despacktivate      # short alias for 'spack env deactivate'
+$ despacktivate      short alias for
 $ spack env status
 ==> No active environment
 $ spack find
-==> 70 installed packages
+==> 63 installed packages
 -- linux-ubuntu18.04-x86_64 / clang@6.0.0 -----------------------
 zlib@1.2.11
 
 -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-adept-utils@1.0.1  gettext@0.20.2     libiberty@2.33.1	   mumps@5.3.3		   pkgconf@1.7.3
-autoconf@2.69	   glm@0.9.7.1	      libiconv@1.16	   ncurses@6.2		   readline@8.0
-automake@1.16.2    gmp@6.1.2	      libpciaccess@0.13.5  netcdf-c@4.7.3	   suite-sparse@5.7.2
-boost@1.72.0	   hdf5@1.10.6	      libsigsegv@2.12	   netcdf-c@4.7.3	   tar@1.32
-boost@1.73.0	   hdf5@1.10.6	      libtool@2.4.6	   netlib-scalapack@2.1.0  tcl@8.6.8
-bzip2@1.0.8	   hdf5@1.10.6	      libxml2@2.9.10	   netlib-scalapack@2.1.0  tcl@8.6.8
-callpath@1.0.4	   hdf5@1.10.6	      m4@1.4.18 	   numactl@2.0.12	   texinfo@6.5
-cmake@3.17.3	   hwloc@1.11.11      matio@1.5.13	   openblas@0.3.10	   trilinos@12.18.1
-diffutils@3.7	   hwloc@2.2.0	      matio@1.5.13	   openmpi@3.1.6	   util-macros@1.19.1
-dyninst@10.1.0	   hypre@2.18.2       metis@5.1.0	   openssl@1.1.1g	   xz@5.2.5
-elfutils@0.179	   hypre@2.18.2       mpc@1.1.0 	   parmetis@4.0.3	   zlib@1.2.8
-findutils@4.6.0    intel-tbb@2020.2   mpfr@3.1.6	   parmetis@4.0.3	   zlib@1.2.8
-gcc@8.3.0	   isl@0.18	      mpich@3.3.2	   patchelf@0.10	   zlib@1.2.11
-gdbm@1.18.1	   libdwarf@20180129  mumps@5.3.3	   perl@5.30.3
+autoconf@2.69		     hdf5@1.10.7	libxml2@2.9.10	netcdf-c@4.7.4		suite-sparse@5.8.1
+autoconf-archive@2019.01.06  hdf5@1.10.7	m4@1.4.18	netlib-scalapack@2.1.0	tcl@8.6.10
+automake@1.16.2 	     hdf5@1.10.7	matio@1.5.17	netlib-scalapack@2.1.0	tcl@8.6.10
+berkeley-db@18.1.40	     hdf5@1.10.7	matio@1.5.17	numactl@2.0.14		texinfo@6.5
+boost@1.74.0		     hwloc@1.11.11	metis@5.1.0	openblas@0.3.12 	trilinos@13.0.1
+bzip2@1.0.8		     hwloc@2.2.0	mpc@1.1.0	openmpi@3.1.6		util-macros@1.19.1
+cmake@3.18.4		     hypre@2.20.0	mpfr@3.1.6	openssl@1.1.1h		xz@5.2.5
+diffutils@3.7		     hypre@2.20.0	mpfr@4.0.2	parmetis@4.0.3		zlib@1.2.8
+findutils@4.6.0 	     isl@0.18		mpich@3.3.2	parmetis@4.0.3		zlib@1.2.8
+gcc@8.3.0		     libiconv@1.16	mumps@5.3.3	patchelf@0.10		zlib@1.2.11
+gdbm@1.18.1		     libpciaccess@0.16	mumps@5.3.3	perl@5.32.0
+glm@0.9.7.1		     libsigsegv@2.12	ncurses@6.2	pkgconf@1.7.3
+gmp@6.1.2		     libtool@2.4.6	netcdf-c@4.7.4	readline@8.0

--- a/outputs/environments/env-swap-1.out
+++ b/outputs/environments/env-swap-1.out
@@ -5,12 +5,14 @@ $ spack find
 ==> Root specs
 tcl   trilinos
 
-==> 37 installed packages
+==> 41 installed packages
 -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-autoconf@2.69	 glm@0.9.7.1	      libtool@2.4.6   netcdf-c@4.7.3	      perl@5.30.3	  xz@5.2.5
-automake@1.16.2  hdf5@1.10.6	      libxml2@2.9.10  netlib-scalapack@2.1.0  pkgconf@1.7.3	  zlib@1.2.11
-boost@1.73.0	 hwloc@1.11.11	      m4@1.4.18       numactl@2.0.12	      readline@8.0
-bzip2@1.0.8	 hypre@2.18.2	      matio@1.5.13    openblas@0.3.10	      suite-sparse@5.7.2
-cmake@3.17.3	 libiconv@1.16	      metis@5.1.0     openmpi@3.1.6	      tcl@8.6.8
-diffutils@3.7	 libpciaccess@0.13.5  mumps@5.3.3     openssl@1.1.1g	      trilinos@12.18.1
-gdbm@1.18.1	 libsigsegv@2.12      ncurses@6.2     parmetis@4.0.3	      util-macros@1.19.1
+autoconf@2.69		     glm@0.9.7.1	libxml2@2.9.10		numactl@2.0.14	    tcl@8.6.10
+autoconf-archive@2019.01.06  gmp@6.1.2		m4@1.4.18		openblas@0.3.12     trilinos@13.0.1
+automake@1.16.2 	     hdf5@1.10.7	matio@1.5.17		openmpi@3.1.6	    util-macros@1.19.1
+berkeley-db@18.1.40	     hwloc@1.11.11	metis@5.1.0		openssl@1.1.1h	    xz@5.2.5
+boost@1.74.0		     hypre@2.20.0	mpfr@4.0.2		parmetis@4.0.3	    zlib@1.2.11
+bzip2@1.0.8		     libiconv@1.16	mumps@5.3.3		perl@5.32.0
+cmake@3.18.4		     libpciaccess@0.16	ncurses@6.2		pkgconf@1.7.3
+diffutils@3.7		     libsigsegv@2.12	netcdf-c@4.7.4		readline@8.0
+gdbm@1.18.1		     libtool@2.4.6	netlib-scalapack@2.1.0	suite-sparse@5.8.1

--- a/outputs/environments/env-uninstall-1.out
+++ b/outputs/environments/env-uninstall-1.out
@@ -1,19 +1,20 @@
 $ spack uninstall trilinos
+y
+
 ==> The following packages will be uninstalled:
 
     -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-    j6dav6k trilinos@12.18.1
+    qmjbxf2 trilinos@13.0.1
 
-==> Do you want to proceed? [y/N] y
-==> Updating view at /home/spack/spack/var/spack/environments/myproject2/.spack-env/view
+==> Do you want to proceed? [y/N] ==> Updating view at /home/spack/spack/var/spack/environments/myproject2/.spack-env/view
 $ spack find
 ==> In environment myproject2
 ==> Root specs
 hdf5 +hl
 
-==> 20 installed packages
+==> 21 installed packages
 -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-autoconf@2.69	 hwloc@1.11.11	      libtool@2.4.6   numactl@2.0.12  readline@8.0
-automake@1.16.2  libiconv@1.16	      libxml2@2.9.10  openmpi@3.1.6   util-macros@1.19.1
-gdbm@1.18.1	 libpciaccess@0.13.5  m4@1.4.18       perl@5.30.3     xz@5.2.5
-hdf5@1.10.6	 libsigsegv@2.12      ncurses@6.2     pkgconf@1.7.3   zlib@1.2.11
+autoconf@2.69	     hdf5@1.10.7	libsigsegv@2.12  ncurses@6.2	 pkgconf@1.7.3	     zlib@1.2.11
+automake@1.16.2      hwloc@1.11.11	libtool@2.4.6	 numactl@2.0.14  readline@8.0
+berkeley-db@18.1.40  libiconv@1.16	libxml2@2.9.10	 openmpi@3.1.6	 util-macros@1.19.1
+gdbm@1.18.1	     libpciaccess@0.16	m4@1.4.18	 perl@5.32.0	 xz@5.2.5

--- a/outputs/environments/find-no-env-1.out
+++ b/outputs/environments/find-no-env-1.out
@@ -1,20 +1,19 @@
 $ spack find
-==> 70 installed packages
+==> 63 installed packages
 -- linux-ubuntu18.04-x86_64 / clang@6.0.0 -----------------------
 zlib@1.2.11
 
 -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-adept-utils@1.0.1  gettext@0.20.2     libiberty@2.33.1	   mumps@5.3.3		   pkgconf@1.7.3
-autoconf@2.69	   glm@0.9.7.1	      libiconv@1.16	   ncurses@6.2		   readline@8.0
-automake@1.16.2    gmp@6.1.2	      libpciaccess@0.13.5  netcdf-c@4.7.3	   suite-sparse@5.7.2
-boost@1.72.0	   hdf5@1.10.6	      libsigsegv@2.12	   netcdf-c@4.7.3	   tar@1.32
-boost@1.73.0	   hdf5@1.10.6	      libtool@2.4.6	   netlib-scalapack@2.1.0  tcl@8.6.8
-bzip2@1.0.8	   hdf5@1.10.6	      libxml2@2.9.10	   netlib-scalapack@2.1.0  tcl@8.6.8
-callpath@1.0.4	   hdf5@1.10.6	      m4@1.4.18 	   numactl@2.0.12	   texinfo@6.5
-cmake@3.17.3	   hwloc@1.11.11      matio@1.5.13	   openblas@0.3.10	   trilinos@12.18.1
-diffutils@3.7	   hwloc@2.2.0	      matio@1.5.13	   openmpi@3.1.6	   util-macros@1.19.1
-dyninst@10.1.0	   hypre@2.18.2       metis@5.1.0	   openssl@1.1.1g	   xz@5.2.5
-elfutils@0.179	   hypre@2.18.2       mpc@1.1.0 	   parmetis@4.0.3	   zlib@1.2.8
-findutils@4.6.0    intel-tbb@2020.2   mpfr@3.1.6	   parmetis@4.0.3	   zlib@1.2.8
-gcc@8.3.0	   isl@0.18	      mpich@3.3.2	   patchelf@0.10	   zlib@1.2.11
-gdbm@1.18.1	   libdwarf@20180129  mumps@5.3.3	   perl@5.30.3
+autoconf@2.69		     hdf5@1.10.7	libxml2@2.9.10	netcdf-c@4.7.4		suite-sparse@5.8.1
+autoconf-archive@2019.01.06  hdf5@1.10.7	m4@1.4.18	netlib-scalapack@2.1.0	tcl@8.6.10
+automake@1.16.2 	     hdf5@1.10.7	matio@1.5.17	netlib-scalapack@2.1.0	tcl@8.6.10
+berkeley-db@18.1.40	     hdf5@1.10.7	matio@1.5.17	numactl@2.0.14		texinfo@6.5
+boost@1.74.0		     hwloc@1.11.11	metis@5.1.0	openblas@0.3.12 	trilinos@13.0.1
+bzip2@1.0.8		     hwloc@2.2.0	mpc@1.1.0	openmpi@3.1.6		util-macros@1.19.1
+cmake@3.18.4		     hypre@2.20.0	mpfr@3.1.6	openssl@1.1.1h		xz@5.2.5
+diffutils@3.7		     hypre@2.20.0	mpfr@4.0.2	parmetis@4.0.3		zlib@1.2.8
+findutils@4.6.0 	     isl@0.18		mpich@3.3.2	parmetis@4.0.3		zlib@1.2.8
+gcc@8.3.0		     libiconv@1.16	mumps@5.3.3	patchelf@0.10		zlib@1.2.11
+gdbm@1.18.1		     libpciaccess@0.16	mumps@5.3.3	perl@5.32.0
+glm@0.9.7.1		     libsigsegv@2.12	ncurses@6.2	pkgconf@1.7.3
+gmp@6.1.2		     libtool@2.4.6	netcdf-c@4.7.4	readline@8.0

--- a/outputs/environments/install-anonymous-1.out
+++ b/outputs/environments/install-anonymous-1.out
@@ -1,70 +1,76 @@
 $ spack env activate .
 $ spack install
 ==> Concretized boost
-[+]  qzr23mk  boost@1.73.0%gcc@7.5.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=246508e052c44b6f4e8c2542a71c06cacaa72cd1447ab8d2a542b987bc35ace9,4dd507e1f5a29e3b87b15321a4d8c74afdc8331433edabf7aeab89b3c405d556 visibility=hidden arch=linux-ubuntu18.04-x86_64
+[+]  hc5atqc  boost@1.74.0%gcc@7.5.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden arch=linux-ubuntu18.04-x86_64
 [+]  fvfpt26	  ^bzip2@1.0.8%gcc@7.5.0+shared arch=linux-ubuntu18.04-x86_64
 [+]  otkkten	      ^diffutils@3.7%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  jearpk4		  ^libiconv@1.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  smoyzzo	  ^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64
 
 ==> Concretized trilinos
-[+]  j6dav6k  trilinos@12.18.1%gcc@7.5.0~adios2~alloptpkgs+amesos+amesos2+anasazi+aztec+belos+boost~cgns~chaco~complex~debug~dtk+epetra+epetraext+exodus+explicit_template_instantiation~float+fortran~fortrilinos+glm+gtest+hdf5+hypre+ifpack+ifpack2~intrepid~intrepid2~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~shards+shared~shylu~stk~stratimikos+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo gotype=long arch=linux-ubuntu18.04-x86_64
-[+]  qzr23mk	  ^boost@1.73.0%gcc@7.5.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 patches=246508e052c44b6f4e8c2542a71c06cacaa72cd1447ab8d2a542b987bc35ace9,4dd507e1f5a29e3b87b15321a4d8c74afdc8331433edabf7aeab89b3c405d556 visibility=hidden arch=linux-ubuntu18.04-x86_64
+[+]  qmjbxf2  trilinos@13.0.1%gcc@7.5.0~adios2~alloptpkgs+amesos+amesos2+anasazi+aztec+belos+boost~cgns~chaco~complex~cuda~debug~dtk+epetra+epetraext+exodus+explicit_template_instantiation~float+fortran+glm+gtest+hdf5~hwloc+hypre+ifpack+ifpack2~intrepid~intrepid2~ipo~isorropia+kokkos+matio~mesquite+metis~minitensor+ml+mpi+muelu+mumps+netcdf~nox~openmp~phalanx~piro~pnetcdf~python~rol~rythmos+sacado~shards+shared~shylu~stk~stratimikos~strumpack+suite-sparse~superlu~superlu-dist~teko~tempus+teuchos+tpetra~wrapper~x11~xsdkflags~zlib+zoltan+zoltan2 build_type=RelWithDebInfo cuda_arch=none cxxstd=11 gotype=long arch=linux-ubuntu18.04-x86_64
+[+]  hc5atqc	  ^boost@1.74.0%gcc@7.5.0+atomic+chrono~clanglibcpp~container~context~coroutine+date_time~debug+exception~fiber+filesystem+graph~icu+iostreams+locale+log+math~mpi+multithreaded~numpy~pic+program_options~python+random+regex+serialization+shared+signals~singlethreaded+system~taggedlayout+test+thread+timer~versionedlayout+wave cxxstd=98 visibility=hidden arch=linux-ubuntu18.04-x86_64
 [+]  fvfpt26	      ^bzip2@1.0.8%gcc@7.5.0+shared arch=linux-ubuntu18.04-x86_64
 [+]  otkkten		  ^diffutils@3.7%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  jearpk4		      ^libiconv@1.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  smoyzzo	      ^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64
-[+]  thpwgui	  ^cmake@3.17.3%gcc@7.5.0~doc+ncurses+openssl+ownlibs~qt arch=linux-ubuntu18.04-x86_64
+[+]  bltycqw	  ^cmake@3.18.4%gcc@7.5.0~doc+ncurses+openssl+ownlibs~qt patches=bf695e3febb222da2ed94b3beea600650e4318975da90e4a71d6f31a6d5d8c3d arch=linux-ubuntu18.04-x86_64
 [+]  crhlefo	      ^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-x86_64
 [+]  4sh6pym		  ^pkgconf@1.7.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  4dj34yw	      ^openssl@1.1.1g%gcc@7.5.0+systemcerts arch=linux-ubuntu18.04-x86_64
-[+]  hyrsxn4		  ^perl@5.30.3%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  es377uq	      ^openssl@1.1.1h%gcc@7.5.0+systemcerts arch=linux-ubuntu18.04-x86_64
+[+]  zfdvt2j		  ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  4ihuiaz		      ^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  4av4gyw		      ^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  t54jzdy			  ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  c3mfw24	  ^glm@0.9.7.1%gcc@7.5.0 build_type=RelWithDebInfo arch=linux-ubuntu18.04-x86_64
-[+]  7r2lztq	  ^hdf5@1.10.6%gcc@7.5.0~cxx~debug~fortran+hl+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
-[+]  wudo6ky	      ^openmpi@3.1.6%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~memchecker~pmi~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
-[+]  ckxpgsn		  ^hwloc@1.11.11%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
-[+]  cmn6yii		      ^libpciaccess@0.13.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  n4xti2g	  ^glm@0.9.7.1%gcc@7.5.0~ipo build_type=RelWithDebInfo arch=linux-ubuntu18.04-x86_64
+[+]  ejanivx	  ^hdf5@1.10.7%gcc@7.5.0~cxx~debug~fortran+hl~java+mpi+pic+shared~szip~threadsafe api=none arch=linux-ubuntu18.04-x86_64
+[+]  pmsyupw	      ^openmpi@3.1.6%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
+[+]  zqwfzhw		  ^hwloc@1.11.11%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
+[+]  bob4o5m		      ^libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  jdxbjft			  ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  mkc3u4x			      ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
 [+]  lbrx7ln				  ^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  gs6ag7k			  ^util-macros@1.19.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  m3l53bh		      ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
-[+]  6nxes4r			  ^xz@5.2.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  yvxocdy		      ^numactl@2.0.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  nwb3bf5			  ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  wdflovn			  ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  dnwivcw	  ^hypre@2.18.2%gcc@7.5.0~complex~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist arch=linux-ubuntu18.04-x86_64
-[+]  m5gktgo	      ^openblas@0.3.10%gcc@7.5.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-x86_64
-[+]  w3dbllq	  ^matio@1.5.13%gcc@7.5.0+hdf5+shared+zlib arch=linux-ubuntu18.04-x86_64
+[+]  yn2r3wf		      ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
+[+]  komekkm			  ^xz@5.2.5%gcc@7.5.0~pic arch=linux-ubuntu18.04-x86_64
+[+]  wbqbc5v		      ^numactl@2.0.14%gcc@7.5.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94 arch=linux-ubuntu18.04-x86_64
+[+]  mm33a3o			  ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  d2krmb5			  ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  nndket2	  ^hypre@2.20.0%gcc@7.5.0~complex~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059 arch=linux-ubuntu18.04-x86_64
+[+]  te35tjx	      ^openblas@0.3.12%gcc@7.5.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-x86_64
+[+]  zoqjxgk	  ^matio@1.5.17%gcc@7.5.0+hdf5+shared+zlib arch=linux-ubuntu18.04-x86_64
 [+]  edcrft4	  ^metis@5.1.0%gcc@7.5.0~gdb~int64~real64+shared build_type=Release patches=4991da938c1d3a1d3dea78e49bbebecba00273f98df2a656e38b83d55b281da1,b1225da886605ea558db7ac08dd8054742ea5afe5ed61ad4d0fe7a495b1270d2 arch=linux-ubuntu18.04-x86_64
-[+]  qb6yumy	  ^mumps@5.3.3%gcc@7.5.0+complex+double+float~int64~metis+mpi~parmetis~ptscotch~scotch+shared arch=linux-ubuntu18.04-x86_64
-[+]  bvapk5o	      ^netlib-scalapack@2.1.0%gcc@7.5.0~pic+shared build_type=RelWithDebInfo patches=f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2 arch=linux-ubuntu18.04-x86_64
-[+]  uctbd5y	  ^netcdf-c@4.7.3%gcc@7.5.0~dap~hdf4~jna+mpi~parallel-netcdf+pic+shared arch=linux-ubuntu18.04-x86_64
-[+]  zdxekoe	  ^parmetis@4.0.3%gcc@7.5.0~gdb+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d arch=linux-ubuntu18.04-x86_64
-[+]  dgppz4n	  ^suite-sparse@5.7.2%gcc@7.5.0~cuda~openmp+pic~tbb arch=linux-ubuntu18.04-x86_64
+[+]  3jmjrzw	  ^mumps@5.3.3%gcc@7.5.0+complex+double+float~int64~metis+mpi~parmetis~ptscotch~scotch+shared arch=linux-ubuntu18.04-x86_64
+[+]  wsiydak	      ^netlib-scalapack@2.1.0%gcc@7.5.0~ipo~pic+shared build_type=Release patches=1c9ce5fee1451a08c2de3cc87f446aeda0b818ebbce4ad0d980ddf2f2a0b2dc4,f2baedde688ffe4c20943c334f580eb298e04d6f35c86b90a1f4e8cb7ae344a2 arch=linux-ubuntu18.04-x86_64
+[+]  yixejly	  ^netcdf-c@4.7.4%gcc@7.5.0~dap~hdf4~jna+mpi~parallel-netcdf+pic+shared arch=linux-ubuntu18.04-x86_64
+[+]  htdsyvt	  ^parmetis@4.0.3%gcc@7.5.0~gdb~int64~ipo+shared build_type=RelWithDebInfo patches=4f892531eb0a807eb1b82e683a416d3e35154a455274cf9b162fb02054d11a5b,50ed2081bc939269689789942067c58b3e522c269269a430d5d34c00edbc5870,704b84f7c7444d4372cb59cca6e1209df4ef3b033bc4ee3cf50f369bce972a9d arch=linux-ubuntu18.04-x86_64
+[+]  rdfmg5b	  ^suite-sparse@5.8.1%gcc@7.5.0~cuda~openmp+pic~tbb arch=linux-ubuntu18.04-x86_64
+[+]  3ol3tld	      ^gmp@6.1.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  mpv2v7v	      ^mpfr@4.0.2%gcc@7.5.0 patches=3f80b836948aa96f8d1cb9cc7f3f55973f19285482a96f9a4e1623d460bcccf0 arch=linux-ubuntu18.04-x86_64
+[+]  bdyarrk		  ^autoconf-archive@2019.01.06%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 
 ==> Concretized openmpi
-[+]  wudo6ky  openmpi@3.1.6%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~memchecker~pmi~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
-[+]  ckxpgsn	  ^hwloc@1.11.11%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
-[+]  cmn6yii	      ^libpciaccess@0.13.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  pmsyupw  openmpi@3.1.6%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
+[+]  zqwfzhw	  ^hwloc@1.11.11%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
+[+]  bob4o5m	      ^libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  jdxbjft		  ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  mkc3u4x		      ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
 [+]  lbrx7ln			  ^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  4sh6pym		  ^pkgconf@1.7.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  gs6ag7k		  ^util-macros@1.19.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  m3l53bh	      ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
+[+]  yn2r3wf	      ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
 [+]  jearpk4		  ^libiconv@1.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  6nxes4r		  ^xz@5.2.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  komekkm		  ^xz@5.2.5%gcc@7.5.0~pic arch=linux-ubuntu18.04-x86_64
 [+]  smoyzzo		  ^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64
-[+]  yvxocdy	      ^numactl@2.0.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  nwb3bf5		  ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-[+]  hyrsxn4		      ^perl@5.30.3%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  wbqbc5v	      ^numactl@2.0.14%gcc@7.5.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94 arch=linux-ubuntu18.04-x86_64
+[+]  mm33a3o		  ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  zfdvt2j		      ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+[+]  4ihuiaz			  ^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  4av4gyw			  ^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  t54jzdy			      ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 [+]  crhlefo				  ^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-x86_64
-[+]  wdflovn		  ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+[+]  d2krmb5		  ^automake@1.16.2%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 
 ==> Installing environment /home/spack/code
+==> All of the packages are already installed
 ==> Updating view at /home/spack/code/.spack-env/view

--- a/outputs/environments/lockfile-1.out
+++ b/outputs/environments/lockfile-1.out
@@ -6,22 +6,22 @@ $ head -30 spack.lock
  },
  "roots": [
   {
-   "hash": "cspsw4ijcdfonvmibeld54hp6covw2if",
+   "hash": "iwji2vty6m7hp27zbzufewdhq6pty3fx",
    "spec": "boost"
   },
   {
-   "hash": "uqdfygm4nzcgw3b4k4vpg4kwogrq2o2z",
+   "hash": "246z4kkzk6vsg2ot3rzlz5jwwimxj63g",
    "spec": "trilinos"
   },
   {
-   "hash": "vseiegeewfblj7sxn5nctaucw2wwdu5t",
+   "hash": "7o7eidaryeh72cizcbpvvjnq7ojjya6f",
    "spec": "openmpi"
   }
  ],
  "concrete_specs": {
-  "cspsw4ijcdfonvmibeld54hp6covw2if": {
+  "iwji2vty6m7hp27zbzufewdhq6pty3fx": {
    "boost": {
-    "version": "1.73.0",
+    "version": "1.74.0",
     "arch": {
      "platform": "linux",
      "platform_os": "ubuntu18.04",

--- a/outputs/environments/show-paths-1.out
+++ b/outputs/environments/show-paths-1.out
@@ -1,10 +1,12 @@
 $ env | grep PATH=
 LIBRARY_PATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib:/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib64
+C_INCLUDE_PATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/include
 LD_LIBRARY_PATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib:/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib64
-PKG_CONFIG_PATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib/pkgconfig:/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib64/pkgconfig
+CPLUS_INCLUDE_PATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/include
+PKG_CONFIG_PATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib/pkgconfig:/home/spack/spack/var/spack/environments/myproject/.spack-env/view/share/pkgconfig:/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib64/pkgconfig
 ACLOCAL_PATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/share/aclocal
 PATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/bin:/home/spack/spack/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-CPATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/include
+PYTHONPATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib
 SPACK_LD_LIBRARY_PATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib:/home/spack/spack/var/spack/environments/myproject/.spack-env/view/lib64
 MANPATH=/home/spack/spack/var/spack/environments/myproject/.spack-env/view/share/man:/home/spack/spack/var/spack/environments/myproject/.spack-env/view/man
 MODULEPATH=/home/spack/spack/share/spack/modules/linux-ubuntu18.04-x86_64

--- a/outputs/environments/spec-1.out
+++ b/outputs/environments/spec-1.out
@@ -5,11 +5,11 @@ hypre
 
 Concretized
 --------------------------------
-hypre@2.18.2%gcc@7.5.0~complex~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist arch=linux-ubuntu18.04-x86_64
-    ^openblas@0.3.10%gcc@7.5.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-x86_64
-    ^openmpi@3.1.6%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~memchecker~pmi~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
+hypre@2.20.0%gcc@7.5.0~complex~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059 arch=linux-ubuntu18.04-x86_64
+    ^openblas@0.3.12%gcc@7.5.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-x86_64
+    ^openmpi@3.1.6%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~java~legacylaunchers~lustre~memchecker~pmi~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64
 	^hwloc@1.11.11%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
-	    ^libpciaccess@0.13.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+	    ^libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 		^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 		    ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
 			^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
@@ -17,11 +17,12 @@ hypre@2.18.2%gcc@7.5.0~complex~debug~int64~internal-superlu~mixedint+mpi~openmp+
 		^util-macros@1.19.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 	    ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
 		^libiconv@1.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-		^xz@5.2.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+		^xz@5.2.5%gcc@7.5.0~pic arch=linux-ubuntu18.04-x86_64
 		^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64
-	    ^numactl@2.0.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+	    ^numactl@2.0.14%gcc@7.5.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94 arch=linux-ubuntu18.04-x86_64
 		^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-		    ^perl@5.30.3%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+		    ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+			^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 			^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 			    ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 				^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-x86_64

--- a/outputs/environments/spec-2.out
+++ b/outputs/environments/spec-2.out
@@ -5,12 +5,13 @@ hypre
 
 Concretized
 --------------------------------
-hypre@2.18.2%gcc@7.5.0~complex~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist arch=linux-ubuntu18.04-x86_64
-    ^mpich@3.3.2%gcc@7.5.0+hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
+hypre@2.20.0%gcc@7.5.0~complex~debug~int64~internal-superlu~mixedint+mpi~openmp+shared~superlu-dist patches=6e3336b1d62155f6350dfe42b0f9ea25d4fa0af60c7e540959139deb93a26059 arch=linux-ubuntu18.04-x86_64
+    ^mpich@3.3.2%gcc@7.5.0~argobots+fortran+hwloc+hydra+libxml2+pci+romio~slurm~verbs+wrapperrpath device=ch3 netmod=tcp patches=eb982de3366d48cbc55eb5e0df43373a45d9f51df208abf0835a72dc6c0b4774 pmi=pmi arch=linux-ubuntu18.04-x86_64
 	^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 	    ^m4@1.4.18%gcc@7.5.0+sigsegv patches=3877ab548f88597ab2327a2230ee048d2d07ace1062efe81fc92e91b7f39cd00,fc9b61654a3ba1a8d6cd78ce087e7c96366c290bc8d2c299f09828d793b853c8 arch=linux-ubuntu18.04-x86_64
 		^libsigsegv@2.12%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-	    ^perl@5.30.3%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+	    ^perl@5.32.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64
+		^berkeley-db@18.1.40%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 		^gdbm@1.18.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 		    ^readline@8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 			^ncurses@6.2%gcc@7.5.0~symlinks+termlib arch=linux-ubuntu18.04-x86_64
@@ -20,11 +21,11 @@ hypre@2.18.2%gcc@7.5.0~complex~debug~int64~internal-superlu~mixedint+mpi~openmp+
 	    ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 	    ^texinfo@6.5%gcc@7.5.0 patches=12f6edb0c6b270b8c8dba2ce17998c580db01182d871ee32b7b6e4129bd1d23a,1732115f651cff98989cb0215d8f64da5e0f7911ebf0c13b064920f088f2ffe1 arch=linux-ubuntu18.04-x86_64
 	^hwloc@2.2.0%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml+pci+shared arch=linux-ubuntu18.04-x86_64
-	    ^libpciaccess@0.13.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+	    ^libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 		^util-macros@1.19.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 	    ^libxml2@2.9.10%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64
 		^libiconv@1.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
-		^xz@5.2.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
+		^xz@5.2.5%gcc@7.5.0~pic arch=linux-ubuntu18.04-x86_64
 		^zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64
-    ^openblas@0.3.10%gcc@7.5.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-x86_64
+    ^openblas@0.3.12%gcc@7.5.0~consistent_fpcsr~ilp64+pic+shared threads=none arch=linux-ubuntu18.04-x86_64
 

--- a/outputs/environments/use-mpi-1.out
+++ b/outputs/environments/use-mpi-1.out
@@ -1,7 +1,7 @@
 $ mpicc ./mpi-hello.c
 $ mpirun -n 4 ./a.out
+Hello world from rank 3
 Hello world from rank 0
+zlib version: 1.2.11
 Hello world from rank 1
 Hello world from rank 2
-Hello world from rank 3
-zlib version: 1.2.11

--- a/outputs/environments/use-trilinos-1.out
+++ b/outputs/environments/use-trilinos-1.out
@@ -18,7 +18,7 @@ $ algebra
 		 FOR POST-PROCESSING OF FINITE ELEMENT ANALYSES
 				EXODUS II VERSION
 
-			  Run on 2020-07-28 at 12:06:08
+			  Run on 2021-04-16 at 07:13:10
 
 	       ==== Email gdsjaar@sandia.gov for support ====
 

--- a/outputs/init_spack.sh
+++ b/outputs/init_spack.sh
@@ -3,7 +3,7 @@
 if [ ! -d ~/spack ]; then
     git clone https://github.com/spack/spack ~/spack
     cd ~/spack
-    git checkout releases/v0.16
+    git checkout ${tutorial_branch}
 else
     cd ~/spack
 fi

--- a/tutorial_environments.rst
+++ b/tutorial_environments.rst
@@ -518,10 +518,10 @@ create``:
 Both of these create a new environment from the old one, but which one you
 choose depends on your needs:
 
-#. ``abstract``: copying the ``spack.yaml`` file allows someone else to build
-your *requirements*, potentially a different way.
+1. ``abstract``: copying the ``spack.yaml`` file allows someone else to build
+   your *requirements*, potentially a different way.
 
-#. ``concrete``: copying the ``spack.lock`` file allows someone else to rebuild
+2. ``concrete``: copying the ``spack.lock`` file allows someone else to rebuild
    your *installation* exactly as you built it.
 
 The first use case can *re-concretize* the same specs on new platforms in order


### PR DESCRIPTION
This isn't done yet -- I still need to run all the commands and change output, but edits would be appreciated on the .rst.

- [x] move environments after basics and before config
- [x] update text to correspond to the new order
- [x] don't repeat the container name in the `Makefile`