### PR TITLE
Clean up video html

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -39,7 +39,7 @@ Annual Meeting 2021. Virtual event. April 16, 2021.
 
 .. raw:: html
 
-   <iframe width="560" height="315" src="https://www.youtube.com/embed/RlczUgwFCJg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+   <iframe width="560" height="315" src="https://www.youtube.com/embed/RlczUgwFCJg" title="YouTube video player" frameborder="0" allowfullscreen></iframe>
 
 .. _live-demos:
 


### PR DESCRIPTION
Commit for the version of the tutorial tagged as `ecp21`. Not sure why the video stopped working, but I stripped out some of the html that seemed pointless. Local preview isn't working for me in VS Code, but this markup matches some examples I found of embedded YouTube videos in .rst files.