### PR TITLE
Environments: Add a note referencing Spack's module docs

### DIFF
--- a/tutorial_environments.rst
+++ b/tutorial_environments.rst
@@ -179,6 +179,15 @@ Running ``spack env activate`` gives you everything in the environment
 on your ``PATH``. Otherwise, you would need to ``spack load`` or
 ``module load`` a package to use it.
 
+.. note::
+
+   Spack can be used to generate module files for HPC clusters.
+   More information can be found in the modules `documentation
+   <https://spack.readthedocs.io/en/latest/module_file_support.html>`_
+   and `tutorial
+   <https://spack-tutorial.readthedocs.io/en/latest/tutorial_modules.html>`_.
+
+
 When you install packages into an environment, they are, by default,
 linked into a single prefix, or *view*. Activating the environment
 with ``spack env activate`` results in subdirectories from the view

--- a/tutorial_environments.rst
+++ b/tutorial_environments.rst
@@ -176,17 +176,12 @@ Using packages
 
 Environments provide a convenient way for using installed packages.
 Running ``spack env activate`` gives you everything in the environment
-on your ``PATH``. Otherwise, you would need to ``spack load`` or
-``module load`` a package to use it.
-
-.. note::
-
-   Spack can be used to generate module files for HPC clusters.
-   More information can be found in the modules `documentation
-   <https://spack.readthedocs.io/en/latest/module_file_support.html>`_
-   and `tutorial
-   <https://spack-tutorial.readthedocs.io/en/latest/tutorial_modules.html>`_.
-
+on your ``PATH``. Otherwise, you would need to use `spack load
+<https://spack.readthedocs.io/en/latest/basic_usage.html#cmd-spack-load>`_
+or `module load
+<https://spack.readthedocs.io/en/latest/module_file_support.html>`_
+for each package in order to set up the environment for the package (and
+its dependencies).
 
 When you install packages into an environment, they are, by default,
 linked into a single prefix, or *view*. Activating the environment


### PR DESCRIPTION
The note pretty much only provides links to the documentation.

The change is a preliminary response to a PEARC tutorial question about environments vs. `spack load` vs. `module load`.