### PR TITLE
Basics: minor updates to tutorial

### DIFF
--- a/outputs/basics.sh
+++ b/outputs/basics.sh
@@ -11,7 +11,7 @@ rm -rf $raw_outputs ~/spack ~/.spack ~/.gnupg
 pip3 install boto3
 
 # basic installation
-example basics/clone         "git clone https://github.com/spack/spack ~/spack"
+example basics/clone         "git clone https://github.com/spack/spack.git ~/spack"
 
 example basics/checkout      "cd ~/spack"
 cd ~/spack

--- a/outputs/basics/clone.out
+++ b/outputs/basics/clone.out
@@ -1,4 +1,4 @@
-$ git clone https://github.com/spack/spack ~/spack
+$ git clone https://github.com/spack/spack.git ~/spack
 Cloning into '/home/spack/spack'...
 remote: Enumerating objects: 326481, done.K
 remote: Counting objects: 100% (770/770), done.K

--- a/tutorial_basics.rst
+++ b/tutorial_basics.rst
@@ -10,16 +10,16 @@ Basic Installation Tutorial
 =========================================
 
 This tutorial will guide you through the process of installing
-software using Spack. We will first cover the `spack install` command,
+software using Spack. We will first cover the ``spack install`` command,
 focusing on the power of the spec syntax and the flexibility it gives
-to users. We will also cover the `spack find` command for viewing
-installed packages and the `spack uninstall` command. Finally, we will
-touch on how Spack manages compilers, especially as it relates to
-using Spack-built compilers within Spack. We will include full output
-from all of the commands demonstrated, although we will frequently
-call attention to only small portions of that output (or merely to the
-fact that it succeeded). The provided output is all from an AWS
-instance running Ubuntu 18.04.
+to users. We will also cover the ``spack find`` command for viewing
+installed packages and the ``spack uninstall`` command for uninstalling
+them. Finally, we will touch on how Spack manages compilers,
+especially as it relates to using Spack-built compilers within Spack.
+We will include full output from all of the commands demonstrated,
+although we will frequently call attention to only small portions of
+that output (or merely to the fact that it succeeded). The provided
+output is all from an AWS instance running Ubuntu 18.04.
 
 .. _basics-tutorial-install:
 
@@ -27,8 +27,8 @@ instance running Ubuntu 18.04.
 Installing Spack
 ----------------
 
-Spack works out of the box. Simply clone Spack and get going. We will
-clone Spack and immediately checkout the most recent release, v0.17.
+Spack works out of the box. Simply clone Spack to get going. We will
+clone Spack and immediately check out the most recent release, v0.17.
 
 .. literalinclude:: outputs/basics/clone.out
    :language: console
@@ -36,7 +36,7 @@ clone Spack and immediately checkout the most recent release, v0.17.
 .. literalinclude:: outputs/basics/checkout.out
    :language: console
 
-Next, add Spack to your path. Spack has some nice command line
+Next, add Spack to your path. Spack has some nice command-line
 integration tools, so instead of simply appending to your ``PATH``
 variable, source the Spack setup script.
 
@@ -91,7 +91,7 @@ You'll learn more about configuring Spack later in the tutorial, but
 for now you will be able to install the rest of the packages in the
 tutorial from a binary cache using the same ``spack install``
 command. By default this will install the binary cached version if it
-exists and fall back on installing from source.
+exists and fall back on installing from source if it does not.
 
 Spack's spec syntax is the interface by which we can request specific
 configurations of the package. The ``%`` sigil is used to specify
@@ -135,6 +135,9 @@ shows the hash of each package, and the ``-f`` flag shows any non-empty
 compiler flags of those packages.
 
 .. literalinclude:: outputs/basics/find.out
+   :language: console
+
+.. literalinclude:: outputs/basics/find-lf.out
    :language: console
 
 Spack generates a hash for each spec. This hash is a function of the full
@@ -183,11 +186,11 @@ we install it "out of the box," it will build with OpenMPI.
    :language: console
 
 Spack packages can also have build options, called variants. Boolean
-variants can be specified using the ``+`` and ``~`` or ``-``
-sigils. There are two sigils for ``False`` to avoid conflicts with
-shell parsing in different situations. Variants (boolean or otherwise)
-can also be specified using the same syntax as compiler flags.  Here
-we can install HDF5 without MPI support.
+variants can be specified using the ``+`` (enable) and ``~`` or ``-``
+(disable) sigils. There are two sigils for "disable" to avoid conflicts
+with shell parsing in different situations. Variants (boolean or
+otherwise) can also be specified using the same syntax as compiler flags.
+Here we can install HDF5 without MPI support.
 
 .. literalinclude:: outputs/basics/hdf5-no-mpi.out
    :language: console
@@ -202,7 +205,7 @@ an MPI dependency. For example, we can build HDF5 with MPI support
 provided by MPICH by specifying a dependency on ``mpich``. Spack also
 supports versioning of virtual dependencies. A package can depend on the
 MPI interface at version 3, and provider packages specify what version of
-the interface *they* provide. The partial spec ``^mpi@3`` can be safisfied
+the interface *they* provide. The partial spec ``^mpi@3`` can be satisfied
 by any of several providers.
 
 .. literalinclude:: outputs/basics/hdf5-hl-mpi.out
@@ -225,10 +228,10 @@ You may also have noticed that there are some packages shown in the
 ``spack find -d`` output that we didn't install explicitly. These are
 dependencies that were installed implicitly. A few packages installed
 implicitly are not shown as dependencies in the ``spack find -d``
-output. These are build dependencies. For example, ``libpciaccess`` is a
-dependency of openmpi and requires ``m4`` to build. Spack will build ``m4`` as
-part of the installation of ``openmpi``, but it does not become a part of
-the DAG because it is not linked in at run time. Spack handles build
+output. These are build dependencies. For example, ``hdf5`` requires
+``cmake`` to build. Spack will build ``cmake`` as part of the
+installation of ``hdf5``, but it does not become a part of the DAG
+because it is not linked in at run time. Spack handles build
 dependencies differently because of their different (less strict)
 consistency requirements. It is entirely possible to have two packages
 using different versions of a dependency to build, which obviously cannot
@@ -236,8 +239,8 @@ be done with linked dependencies.
 
 HDF5 is more complicated than our basic example of zlib and
 Tcl, but it's still within the realm of software that an experienced
-HPC user could reasonably expect to install given a bit of time. Now
-let's look at an even more complicated package.
+HPC user could reasonably expect to manually install given a bit of time.
+Now let's look at an even more complicated package.
 
 .. literalinclude:: outputs/basics/trilinos.out
    :language: console
@@ -351,7 +354,7 @@ return every package which was built with ``cppflags="-O3"``.
 The ``find`` command can also show which packages were installed
 explicitly (rather than pulled in as a dependency) using the ``-x``
 flag. The ``-X`` flag shows implicit installs only. The ``find`` command can
-also show the path to which a spack package was installed using the ``-p``
+also show the path to which a Spack package was installed using the ``-p``
 flag.
 
 .. literalinclude:: outputs/basics/find-px.out


### PR DESCRIPTION
Mostly minor updates to grammar. There was a missing section of output that I added.

Other bugs that I noticed but didn't attempt to fix:

Error during cmake installation.
```console
==> Installing cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea
==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4/linux-ubuntu18.04-x86_64-gcc-7.5.0-cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea.spack
==> Extracting cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea from binary cache
==> Warning: patchelf --print-rpath /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea/share/cmake-3.21/Modules/Internal/CPack/CPack.OSXScriptLauncher.in produced an error [Command exited with status 1:
    '/home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/patchelf-0.13-2txxradgazf7zvc5kzwmc26oqjuop7ej/bin/patchelf' '--print-rpath' '/home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea/share/cmake-3.21/Modules/Internal/CPack/CPack.OSXScriptLauncher.in'
patchelf: not an ELF executable
]
==> Warning: patchelf --force-rpath --set-rpath /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea/share/cmake-3.21/Modules/Internal/CPack/CPack.OSXScriptLauncher.in failed with error Command exited with status 1:
    '/home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/patchelf-0.13-2txxradgazf7zvc5kzwmc26oqjuop7ej/bin/patchelf' '--force-rpath' '--set-rpath' '' '/home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea/share/cmake-3.21/Modules/Internal/CPack/CPack.OSXScriptLauncher.in'
patchelf: not an ELF executable

[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea
```
Also, when we discuss explicitly vs implicitly installed packages, patchelf is showing up as explicit even though it should be implicit.
```console
$ spack find -px
==> 11 installed packages
-- linux-ubuntu18.04-x86_64 / clang@7.0.0 -----------------------
zlib@1.2.11  /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/clang-7.0.0/zlib-1.2.11-atdrszvduszjw55p5g7fnjezpb5l6veu

-- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
hdf5@1.10.7	 /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.10.7-5goewlhuzqaxioxo3enjtrk3354jnqa6
hdf5@1.10.7	 /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.10.7-vt7sza3ycdsw62lk3f2dtnlvmeyihe3r
hdf5@1.10.7	 /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.10.7-qbip6imivdrn2fzofyniujqfxp4v5qrq
patchelf@0.13	 /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/patchelf-0.13-2txxradgazf7zvc5kzwmc26oqjuop7ej
tcl@8.6.11	 /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/tcl-8.6.11-asjutitl4u5c7qnuihi44rk5jxrqfw3h
tcl@8.6.11	 /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/tcl-8.6.11-oysrbhtudfatk3qz655qxf52lpyy32ag
trilinos@13.0.1  /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/trilinos-13.0.1-qeqaxlemmrjym5bhs3ni747mctvklafz
zlib@1.2.8	 /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.8-4njczleoib56k2kczohm4gc5gb2b2y5j
zlib@1.2.8	 /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.8-5wzra4bls7jurzo6knqfa77xhcv6p36l
zlib@1.2.11	 /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11-3rlgy7ycxtoho44una6o3itgfjltkmpd
```

@tgamblin @alalazo 