### PR TITLE
Update S3 buildcache URL, add deprecated:true in config

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04 AS stage
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    REMOTE_BUILDCACHE_URL="s3://spack-binaries/tutorial"
+    REMOTE_BUILDCACHE_URL="s3://spack-binaries/releases/v0.18/tutorial"
 
 # Install AWS cli
 RUN apt-get update -y && \
@@ -16,7 +16,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 # Download the buildcache 
 RUN mkdir /mirror
-RUN aws --region us-east-1 --no-sign-request s3 sync s3://spack-binaries/tutorial /mirror
+RUN aws --region us-east-1 --no-sign-request s3 sync s3://spack-binaries/releases/v0.18/tutorial /mirror
+RUN rm -rf /mirror/buid_cache/_pgp
+RUN aws --region us-east-1 --no-sign-request s3 sync s3://spack-binaries/releases/v0.18/build_cache/_pgp /mirror/build_cache/_pgp
 
 FROM ubuntu:18.04 as builder
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04 AS stage
 
 ENV DEBIAN_FRONTEND=noninteractive \
-    REMOTE_BUILDCACHE_URL="s3://spack-binaries-develop/tutorial"
+    REMOTE_BUILDCACHE_URL="s3://spack-binaries/tutorial"
 
 # Install AWS cli
 RUN apt-get update -y && \
@@ -16,7 +16,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 # Download the buildcache 
 RUN mkdir /mirror
-RUN aws --region us-east-1 --no-sign-request s3 sync s3://spack-binaries-develop/tutorial /mirror
+RUN aws --region us-east-1 --no-sign-request s3 sync s3://spack-binaries/tutorial /mirror
 
 FROM ubuntu:18.04 as builder
 

--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -1,2 +1,6 @@
 config:
   suppress_gpg_warnings: true
+  # This is needed to be able to use zlib@1.2.11
+  # or earlier as of v0.18.0
+  deprecated: true
+

--- a/outputs/Makefile
+++ b/outputs/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all replay
 
 # name of the container we'll generate the tutorial outputs with
-container = ghcr.io/spack/tutorial:latest
+container = spack/tutorial:latest
 raw_output = raw/*/*.out
 subdirs = basics environments packaging environments stacks dev scripting
 

--- a/outputs/defs.sh
+++ b/outputs/defs.sh
@@ -11,7 +11,7 @@ fi
 raw_outputs="${PROJECT}/raw"
 
 # used by scripts
-tutorial_branch=releases/v0.17
+tutorial_branch=releases/v0.18
 
 example() {
     if [[ "$1" == "-tee" ]]; then


### PR DESCRIPTION
To create a docker image to update the output files, from within the `docker` directory:
```console
$ docker build -t spack/tutorial:latest .
```
