### PR TITLE
Update/v18 scripting tutorial

### DIFF
--- a/outputs/Makefile
+++ b/outputs/Makefile
@@ -11,7 +11,7 @@ all:
 	echo "Filtering raw outputs though col"
 	for raw in $(raw_output); do \
 		out=$$(echo $$raw | sed 's.raw/..'); \
-		cat $$raw | perl -pe 's/\033\[([01];)?\d+m//g' | col -bp > $$out; \
+		cat $$raw | perl -pe 's/\x1b\[\d+F\x1b\[J//g' | perl -pe 's/\033\[([01];)?\d+m//g' | col -bp > $$out; \
 	done
 	echo "Removing spurious = and # characters"
 	for dir in $(subdirs); do \

--- a/outputs/scripting/find-exclude-1.out
+++ b/outputs/scripting/find-exclude-1.out
@@ -1,5 +1,5 @@
 $ spack python find_exclude.py %gcc ^mpich
 -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-autoconf@2.69	     bzip2@1.0.8    gdbm@1.19	 libedit@3.1-20210216  libpciaccess@0.16  libxml2@2.9.12  numactl@2.0.14  openssl@1.1.1l  pkgconf@1.8.0       xz@5.2.5
-automake@1.16.3      cmake@3.21.4   hdf5@1.10.7  libevent@2.1.12       libsigsegv@2.13	  m4@1.4.19	  openmpi@4.1.1   patchelf@0.13   readline@8.1	      zlib@1.2.11
-berkeley-db@18.1.40  diffutils@3.8  hwloc@2.6.0  libiconv@1.16	       libtool@2.4.6	  ncurses@6.2	  openssh@8.7p1   perl@5.34.0	  util-macros@1.19.3
+autoconf@2.69	     bzip2@1.0.8    gdbm@1.19	 libedit@3.1-20210216  libpciaccess@0.16  libxml2@2.9.13  numactl@2.0.14  openssl@1.1.1o  pmix@4.1.2	      xz@5.2.5
+automake@1.16.5      cmake@3.23.1   hdf5@1.12.2  libevent@2.1.12       libsigsegv@2.13	  m4@1.4.19	  openmpi@4.1.3   perl@5.34.1	  readline@8.1	      zlib@1.2.12
+berkeley-db@18.1.40  diffutils@3.8  hwloc@2.7.1  libiconv@1.16	       libtool@2.4.7	  ncurses@6.2	  openssh@9.0p1   pkgconf@1.8.0   util-macros@1.19.3

--- a/outputs/scripting/find-exclude-3.out
+++ b/outputs/scripting/find-exclude-3.out
@@ -1,5 +1,5 @@
 $ ./find_exclude.py %gcc ^mpich
 -- linux-ubuntu18.04-x86_64 / gcc@7.5.0 -------------------------
-autoconf@2.69	     bzip2@1.0.8    gdbm@1.19	 libedit@3.1-20210216  libpciaccess@0.16  libxml2@2.9.12  numactl@2.0.14  openssl@1.1.1l  pkgconf@1.8.0       xz@5.2.5
-automake@1.16.3      cmake@3.21.4   hdf5@1.10.7  libevent@2.1.12       libsigsegv@2.13	  m4@1.4.19	  openmpi@4.1.1   patchelf@0.13   readline@8.1	      zlib@1.2.11
-berkeley-db@18.1.40  diffutils@3.8  hwloc@2.6.0  libiconv@1.16	       libtool@2.4.6	  ncurses@6.2	  openssh@8.7p1   perl@5.34.0	  util-macros@1.19.3
+autoconf@2.69	     bzip2@1.0.8    gdbm@1.19	 libedit@3.1-20210216  libpciaccess@0.16  libxml2@2.9.13  numactl@2.0.14  openssl@1.1.1o  pmix@4.1.2	      xz@5.2.5
+automake@1.16.5      cmake@3.23.1   hdf5@1.12.2  libevent@2.1.12       libsigsegv@2.13	  m4@1.4.19	  openmpi@4.1.3   perl@5.34.1	  readline@8.1	      zlib@1.2.12
+berkeley-db@18.1.40  diffutils@3.8  hwloc@2.7.1  libiconv@1.16	       libtool@2.4.7	  ncurses@6.2	  openssh@9.0p1   pkgconf@1.8.0   util-macros@1.19.3

--- a/outputs/scripting/find-format.out
+++ b/outputs/scripting/find-format.out
@@ -1,6 +1,6 @@
 $ spack find --format "{name} {version} {hash:10}"
-autoconf 2.69 7hurwa7yme	diffutils 3.8 kg5jymjbqj	 libevent 2.1.12 xai6pycqx4    libxml2 2.9.12 2hw4ddh7db  openssh 8.7p1 ux36qlbxdg   readline 8.1 27u6g7pchc
-automake 1.16.3 6rqxcsn5r7	gdbm 1.19 oftaepjeli		 libiconv 1.16 qi7dxj6rgd      m4 1.4.19 ybvezwzldr	  openssl 1.1.1l lygx3cqqbv  util-macros 1.19.3 h5cf2g4fze
-berkeley-db 18.1.40 ue5lnfmm3y	hdf5 1.10.7 vt7sza3ycd		 libpciaccess 0.16 ryhmw2gqee  ncurses 6.2 d34lizgt45	  patchelf 0.13 2txxradgaz   xz 5.2.5 nplaapsuxr
-bzip2 1.0.8 55rtzz4s6m		hwloc 2.6.0 gedgnpght7		 libsigsegv 2.13 g2vgcnev7a    numactl 2.0.14 3opot4q2nx  perl 5.34.0 672tzldkvy     zlib 1.2.11 atdrszvdus
-cmake 3.21.4 anj6kcxdxz 	libedit 3.1-20210216 3lzuqwnyue  libtool 2.4.6 2kia6gf4yz      openmpi 4.1.1 p5qicacmcy   pkgconf 1.8.0 ucp6vz7fe6   zlib 1.2.11 3rlgy7ycxt
+autoconf 2.69 hlj3ujmrsu	diffutils 3.8 k22pe4rhr7	 libevent 2.1.12 hlnkgmrdcy    libxml2 2.9.13 4run532u4c  openssh 9.0p1 3ez3d3jtc4   readline 8.1 ls6erxwsj2
+automake 1.16.5 6vk5ehdtjz	gdbm 1.19 xub4jsy5pz		 libiconv 1.16 dr56jt456u      m4 1.4.19 uadbn2a64h	  openssl 1.1.1o hqlqpsnqoi  util-macros 1.19.3 vkk73ww5p7
+berkeley-db 18.1.40 q6tqmmmitk	hdf5 1.12.2 rh2gilz6xl		 libpciaccess 0.16 csp5gvqmwc  ncurses 6.2 frwzsc4jro	  perl 5.34.1 pn5mteswuj     xz 5.2.5 olptpbsse7
+bzip2 1.0.8 cyn2yamiu2		hwloc 2.7.1 oixja6dnsn		 libsigsegv 2.13 ubezeychw4    numactl 2.0.14 wfnw532l74  pkgconf 1.8.0 i5po27g2n6   zlib 1.2.12 3svypjaie5
+cmake 3.23.1 tulqz4nxor 	libedit 3.1-20210216 zc56lv6gyj  libtool 2.4.7 7fhdrxxize      openmpi 4.1.3 jfxctqwar7   pmix 4.1.2 e4fax4744g      zlib 1.2.12 fntvsj6xev

--- a/outputs/scripting/find-json.out
+++ b/outputs/scripting/find-json.out
@@ -2,7 +2,7 @@ $ spack find --json zlib
 [
   {
     "name": "zlib",
-    "version": "1.2.11",
+    "version": "1.2.12",
     "arch": {
       "platform": "linux",
       "platform_os": "ubuntu18.04",
@@ -15,6 +15,9 @@ $ spack find --json zlib
     "namespace": "builtin",
     "parameters": {
       "optimize": true,
+      "patches": [
+	"0d38234384870bfd34dfcb738a9083952656f0c766a0f5990b1893076b084b76"
+      ],
       "pic": true,
       "shared": true,
       "cflags": [],
@@ -24,12 +27,14 @@ $ spack find --json zlib
       "ldflags": [],
       "ldlibs": []
     },
-    "hash": "atdrszvduszjw55p5g7fnjezpb5l6veu",
-    "full_hash": "o7eooyu7rbmvdj6csiwjcbgyzrtxf5bf"
+    "patches": [
+      "0d38234384870bfd34dfcb738a9083952656f0c766a0f5990b1893076b084b76"
+    ],
+    "hash": "3svypjaie5farii5zcgm6yfu43la2ixs"
   },
   {
     "name": "zlib",
-    "version": "1.2.11",
+    "version": "1.2.12",
     "arch": {
       "platform": "linux",
       "platform_os": "ubuntu18.04",
@@ -42,6 +47,9 @@ $ spack find --json zlib
     "namespace": "builtin",
     "parameters": {
       "optimize": true,
+      "patches": [
+	"0d38234384870bfd34dfcb738a9083952656f0c766a0f5990b1893076b084b76"
+      ],
       "pic": true,
       "shared": true,
       "cflags": [],
@@ -51,6 +59,8 @@ $ spack find --json zlib
       "ldflags": [],
       "ldlibs": []
     },
-    "hash": "3rlgy7ycxtoho44una6o3itgfjltkmpd",
-    "full_hash": "svvrv2zzgiqm6iponmexjj6i6bu2sld6"
+    "patches": [
+      "0d38234384870bfd34dfcb738a9083952656f0c766a0f5990b1893076b084b76"
+    ],
+    "hash": "fntvsj6xevbz5gyq7kfa4xg7oxnaolxs"
   }

--- a/outputs/scripting/setup.out
+++ b/outputs/scripting/setup.out
@@ -1,174 +1,220 @@
 $ spack uninstall -ay
-==> Successfully uninstalled patchelf@0.13%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/2txxrad
-==> Successfully uninstalled gcc@8.4.0%gcc@7.5.0~binutils+bootstrap~graphite~nvptx~piclibs~strip languages=c,c++,fortran patches=b48e48736062e64a6da7cbe7e21a6c1c89422d1f49ef547c73b479a3f3f4935f arch=linux-ubuntu18.04-x86_64/jmhauhy
-==> Successfully uninstalled diffutils@3.8%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/kg5jymj
-==> Successfully uninstalled zlib@1.2.11%clang@7.0.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64/atdrszv
-==> Successfully uninstalled autoconf@2.69%gcc@7.5.0 patches=35c449281546376449766f92d49fc121ca50e330e60fefcfc9be2af3253082c2,7793209b33013dc0f81208718c68440c5aae80e7a1c4b8d336e382525af791a7,a49dd5bac3b62daa0ff688ab4d508d71dbd2f4f8d7e2a02321926346161bf3ee arch=linux-ubuntu18.04-x86_64/7hurwa7
-==> Successfully uninstalled util-macros@1.19.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/h5cf2g4
-==> Successfully uninstalled libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/2kia6gf
-==> Successfully uninstalled automake@1.16.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/6rqxcsn
-==> Successfully uninstalled cmake@3.21.4%gcc@7.5.0~doc+ncurses+openssl+ownlibs~qt build_type=Release arch=linux-ubuntu18.04-x86_64/anj6kcx
-==> Successfully uninstalled hdf5@1.10.7%gcc@7.5.0~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_type=RelWithDebInfo arch=linux-ubuntu18.04-x86_64/vt7sza3
-==> Successfully uninstalled m4@1.4.19%gcc@7.5.0+sigsegv patches=9dc5fbd0d5cb1037ab1e6d0ecc74a30df218d0a94bdd5a02759a97f62daca573,bfdffa7c2eb01021d5849b36972c069693654ad826c1a20b53534009a4ec7a89 arch=linux-ubuntu18.04-x86_64/ybvezwz
-==> Successfully uninstalled openmpi@4.1.1%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions+gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker~pmi~pmix~singularity~sqlite3+static~thread_multiple+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64/p5qicac
-==> Successfully uninstalled perl@5.34.0%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64/672tzld
-==> Successfully uninstalled mpc@1.1.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/tjv2csr
-==> Successfully uninstalled pkgconf@1.8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/ucp6vz7
-==> Successfully uninstalled hwloc@2.6.0%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml~opencl+pci~rocm+shared arch=linux-ubuntu18.04-x86_64/gedgnpg
-==> Successfully uninstalled berkeley-db@18.1.40%gcc@7.5.0+cxx~docs+stl patches=b231fcc4d5cff05e5c3a4814f6a5af0e9a966428dc2176540d2c05aff41de522 arch=linux-ubuntu18.04-x86_64/ue5lnfm
-==> Successfully uninstalled gdbm@1.19%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/oftaepj
-==> Successfully uninstalled mpfr@3.1.6%gcc@7.5.0 patches=7a6dd71bcda4803d6b89612706a17b8816e1acd5dd9bf1bec29cf748f3b60008 arch=linux-ubuntu18.04-x86_64/z7hztfv
-==> Successfully uninstalled bzip2@1.0.8%gcc@7.5.0~debug~pic+shared arch=linux-ubuntu18.04-x86_64/55rtzz4
-==> Successfully uninstalled openssh@8.7p1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/ux36qlb
-==> Successfully uninstalled numactl@2.0.14%gcc@7.5.0 patches=4e1d78cbbb85de625bad28705e748856033eaafab92a66dffd383a3d7e00cc94,62fc8a8bf7665a60e8f4c93ebbd535647cebf74198f7afafec4c085a8825c006,ff37630df599cfabf0740518b91ec8daaf18e8f288b19adaae5364dc1f6b2296 arch=linux-ubuntu18.04-x86_64/3opot4q
-==> Successfully uninstalled libevent@2.1.12%gcc@7.5.0+openssl arch=linux-ubuntu18.04-x86_64/xai6pyc
-==> Successfully uninstalled libsigsegv@2.13%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/g2vgcne
-==> Successfully uninstalled libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/ryhmw2g
-==> Successfully uninstalled libxml2@2.9.12%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64/2hw4ddh
-==> Successfully uninstalled readline@8.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/27u6g7p
-==> Successfully uninstalled openssl@1.1.1l%gcc@7.5.0~docs certs=system arch=linux-ubuntu18.04-x86_64/lygx3cq
-==> Successfully uninstalled gmp@6.2.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/7kpzyzg
-==> Successfully uninstalled libedit@3.1-20210216%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/3lzuqwn
-==> Successfully uninstalled ncurses@6.2%gcc@7.5.0~symlinks+termlib abi=none arch=linux-ubuntu18.04-x86_64/d34lizg
-==> Successfully uninstalled xz@5.2.5%gcc@7.5.0~pic libs=shared,static arch=linux-ubuntu18.04-x86_64/nplaaps
-==> Successfully uninstalled libiconv@1.16%gcc@7.5.0 libs=shared,static arch=linux-ubuntu18.04-x86_64/qi7dxj6
-==> Successfully uninstalled zlib@1.2.11%gcc@7.5.0+optimize+pic+shared arch=linux-ubuntu18.04-x86_64/3rlgy7y
+==> Successfully uninstalled gawk@5.1.1%gcc@7.5.0~nls arch=linux-ubuntu18.04-x86_64/ejl2btv
+==> Successfully uninstalled diffutils@3.8%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/k22pe4r
+==> Successfully uninstalled autoconf@2.69%gcc@7.5.0 patches=35c4492,7793209,a49dd5b arch=linux-ubuntu18.04-x86_64/hlj3ujm
+==> Successfully uninstalled util-macros@1.19.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/vkk73ww
+==> Successfully uninstalled hdf5@1.12.2%gcc@7.5.0~cxx~fortran~hl~ipo~java+mpi+shared~szip~threadsafe+tools api=default build_type=RelWithDebInfo arch=linux-ubuntu18.04-x86_64/rh2gilz
+==> Successfully uninstalled zlib@1.2.12%clang@7.0.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu18.04-x86_64/3svypja
+==> Successfully uninstalled cmake@3.23.1%gcc@7.5.0~doc+ncurses+ownlibs~qt build_type=Release arch=linux-ubuntu18.04-x86_64/tulqz4n
+==> Successfully uninstalled automake@1.16.5%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/6vk5ehd
+==> Successfully uninstalled libtool@2.4.7%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/7fhdrxx
+==> Successfully uninstalled mpc@1.1.0%gcc@7.5.0 libs=shared,static arch=linux-ubuntu18.04-x86_64/lmcyfxq
+==> Successfully uninstalled texinfo@6.5%gcc@7.5.0 patches=12f6edb,1732115 arch=linux-ubuntu18.04-x86_64/ot5b2ak
+==> Successfully uninstalled perl@5.34.1%gcc@7.5.0+cpanm+shared+threads arch=linux-ubuntu18.04-x86_64/pn5mtes
+==> Successfully uninstalled openmpi@4.1.3%gcc@7.5.0~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker~pmi+romio+rsh~singularity+static+vt+wrapper-rpath fabrics=none schedulers=none arch=linux-ubuntu18.04-x86_64/jfxctqw
+==> Successfully uninstalled mpfr@3.1.6%gcc@7.5.0 libs=shared,static patches=7a6dd71 arch=linux-ubuntu18.04-x86_64/vmql5cb
+==> Successfully uninstalled m4@1.4.19%gcc@7.5.0+sigsegv patches=9dc5fbd,bfdffa7 arch=linux-ubuntu18.04-x86_64/uadbn2a
+==> Successfully uninstalled pkgconf@1.8.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/i5po27g
+==> Successfully uninstalled gdbm@1.19%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/xub4jsy
+==> Successfully uninstalled berkeley-db@18.1.40%gcc@7.5.0+cxx~docs+stl patches=b231fcc arch=linux-ubuntu18.04-x86_64/q6tqmmm
+==> Successfully uninstalled bzip2@1.0.8%gcc@7.5.0~debug~pic+shared arch=linux-ubuntu18.04-x86_64/cyn2yam
+==> Successfully uninstalled openssh@9.0p1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/3ez3d3j
+==> Successfully uninstalled pmix@4.1.2%gcc@7.5.0~docs+pmi_backwards_compatibility~restful arch=linux-ubuntu18.04-x86_64/e4fax47
+==> Successfully uninstalled gmp@6.2.1%gcc@7.5.0 libs=shared,static arch=linux-ubuntu18.04-x86_64/lf7yoxu
+==> Successfully uninstalled numactl@2.0.14%gcc@7.5.0 patches=4e1d78c,62fc8a8,ff37630 arch=linux-ubuntu18.04-x86_64/wfnw532
+==> Successfully uninstalled libsigsegv@2.13%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/ubezeyc
+==> Successfully uninstalled readline@8.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/ls6erxw
+==> Successfully uninstalled libevent@2.1.12%gcc@7.5.0+openssl arch=linux-ubuntu18.04-x86_64/hlnkgmr
+==> Successfully uninstalled libedit@3.1-20210216%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/zc56lv6
+==> Successfully uninstalled hwloc@2.7.1%gcc@7.5.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml~opencl+pci~rocm+shared arch=linux-ubuntu18.04-x86_64/oixja6d
+==> Successfully uninstalled openssl@1.1.1o%gcc@7.5.0~docs~shared certs=system arch=linux-ubuntu18.04-x86_64/hqlqpsn
+==> Successfully uninstalled libpciaccess@0.16%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64/csp5gvq
+==> Successfully uninstalled libxml2@2.9.13%gcc@7.5.0~python arch=linux-ubuntu18.04-x86_64/4run532
+==> Successfully uninstalled ncurses@6.2%gcc@7.5.0~symlinks+termlib abi=none arch=linux-ubuntu18.04-x86_64/frwzsc4
+==> Successfully uninstalled xz@5.2.5%gcc@7.5.0~pic libs=shared,static arch=linux-ubuntu18.04-x86_64/olptpbs
+==> Successfully uninstalled libiconv@1.16%gcc@7.5.0 libs=shared,static arch=linux-ubuntu18.04-x86_64/dr56jt4
+==> Successfully uninstalled zlib@1.2.12%gcc@7.5.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu18.04-x86_64/fntvsj6
 $ spack compiler rm gcc@8.4.0
 ==> Removed compiler gcc@8.4.0
 $ spack install hdf5
-==> Installing pkgconf-1.8.0-ucp6vz7fe6ihtcmqav3vucwgqjwyw7po
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/pkgconf-1.8.0/linux-ubuntu18.04-x86_64-gcc-7.5.0-pkgconf-1.8.0-ucp6vz7fe6ihtcmqav3vucwgqjwyw7po.spack
-==> Extracting pkgconf-1.8.0-ucp6vz7fe6ihtcmqav3vucwgqjwyw7po from binary cache
-==> Installing patchelf-0.13-2txxradgazf7zvc5kzwmc26oqjuop7ej
-==> No binary for patchelf-0.13-2txxradgazf7zvc5kzwmc26oqjuop7ej found: installing from source
-==> Using cached archive: /home/spack/spack/var/spack/cache/_source-cache/archive/4c/4c7ed4bcfc1a114d6286e4a0d3c1a90db147a4c3adda1814ee0eee0f9ee917ed.tar.bz2
-==> No patches needed for patchelf
-==> patchelf: Executing phase: 'autoreconf'
-==> patchelf: Executing phase: 'configure'
-==> patchelf: Executing phase: 'build'
-==> patchelf: Executing phase: 'install'
-==> patchelf: Successfully installed patchelf-0.13-2txxradgazf7zvc5kzwmc26oqjuop7ej
-  Fetch: 0.01s.  Build: 7.16s.	Total: 7.16s.
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/patchelf-0.13-2txxradgazf7zvc5kzwmc26oqjuop7ej
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/pkgconf-1.8.0-ucp6vz7fe6ihtcmqav3vucwgqjwyw7po
-==> Installing berkeley-db-18.1.40-ue5lnfmm3yaiwm2jha4pnbg2s4h7jaqb
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/berkeley-db-18.1.40/linux-ubuntu18.04-x86_64-gcc-7.5.0-berkeley-db-18.1.40-ue5lnfmm3yaiwm2jha4pnbg2s4h7jaqb.spack
-==> Extracting berkeley-db-18.1.40-ue5lnfmm3yaiwm2jha4pnbg2s4h7jaqb from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/berkeley-db-18.1.40-ue5lnfmm3yaiwm2jha4pnbg2s4h7jaqb
-==> Installing libiconv-1.16-qi7dxj6rgdydno5mdjzyolz6applztig
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16/linux-ubuntu18.04-x86_64-gcc-7.5.0-libiconv-1.16-qi7dxj6rgdydno5mdjzyolz6applztig.spack
-==> Extracting libiconv-1.16-qi7dxj6rgdydno5mdjzyolz6applztig from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16-qi7dxj6rgdydno5mdjzyolz6applztig
-==> Installing zlib-1.2.11-3rlgy7ycxtoho44una6o3itgfjltkmpd
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11/linux-ubuntu18.04-x86_64-gcc-7.5.0-zlib-1.2.11-3rlgy7ycxtoho44una6o3itgfjltkmpd.spack
-==> Extracting zlib-1.2.11-3rlgy7ycxtoho44una6o3itgfjltkmpd from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11-3rlgy7ycxtoho44una6o3itgfjltkmpd
-==> Installing libsigsegv-2.13-g2vgcnev7aspdihdmfbviefdbinclpy7
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libsigsegv-2.13/linux-ubuntu18.04-x86_64-gcc-7.5.0-libsigsegv-2.13-g2vgcnev7aspdihdmfbviefdbinclpy7.spack
-==> Extracting libsigsegv-2.13-g2vgcnev7aspdihdmfbviefdbinclpy7 from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libsigsegv-2.13-g2vgcnev7aspdihdmfbviefdbinclpy7
-==> Installing util-macros-1.19.3-h5cf2g4fzeytdsypsm5gsb4h6saddfev
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/util-macros-1.19.3/linux-ubuntu18.04-x86_64-gcc-7.5.0-util-macros-1.19.3-h5cf2g4fzeytdsypsm5gsb4h6saddfev.spack
-==> Extracting util-macros-1.19.3-h5cf2g4fzeytdsypsm5gsb4h6saddfev from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/util-macros-1.19.3-h5cf2g4fzeytdsypsm5gsb4h6saddfev
-==> Installing xz-5.2.5-nplaapsuxr5djslmxm6sdmaw2xl4d2ti
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/xz-5.2.5/linux-ubuntu18.04-x86_64-gcc-7.5.0-xz-5.2.5-nplaapsuxr5djslmxm6sdmaw2xl4d2ti.spack
-==> Extracting xz-5.2.5-nplaapsuxr5djslmxm6sdmaw2xl4d2ti from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/xz-5.2.5-nplaapsuxr5djslmxm6sdmaw2xl4d2ti
-==> Installing ncurses-6.2-d34lizgt45miuctn4cmx7quklvukdd2w
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/ncurses-6.2/linux-ubuntu18.04-x86_64-gcc-7.5.0-ncurses-6.2-d34lizgt45miuctn4cmx7quklvukdd2w.spack
-==> Extracting ncurses-6.2-d34lizgt45miuctn4cmx7quklvukdd2w from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/ncurses-6.2-d34lizgt45miuctn4cmx7quklvukdd2w
-==> Installing diffutils-3.8-kg5jymjbqjurpq52nvycbddt5ia5uypy
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/diffutils-3.8/linux-ubuntu18.04-x86_64-gcc-7.5.0-diffutils-3.8-kg5jymjbqjurpq52nvycbddt5ia5uypy.spack
-==> Extracting diffutils-3.8-kg5jymjbqjurpq52nvycbddt5ia5uypy from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/diffutils-3.8-kg5jymjbqjurpq52nvycbddt5ia5uypy
-==> Installing m4-1.4.19-ybvezwzldr6ibw767ihpeoal625y76qb
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/m4-1.4.19/linux-ubuntu18.04-x86_64-gcc-7.5.0-m4-1.4.19-ybvezwzldr6ibw767ihpeoal625y76qb.spack
-==> Extracting m4-1.4.19-ybvezwzldr6ibw767ihpeoal625y76qb from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/m4-1.4.19-ybvezwzldr6ibw767ihpeoal625y76qb
-==> Installing libxml2-2.9.12-2hw4ddh7dbtl3wcw5hrt4kk2fkwhfuzj
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libxml2-2.9.12/linux-ubuntu18.04-x86_64-gcc-7.5.0-libxml2-2.9.12-2hw4ddh7dbtl3wcw5hrt4kk2fkwhfuzj.spack
-==> Extracting libxml2-2.9.12-2hw4ddh7dbtl3wcw5hrt4kk2fkwhfuzj from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libxml2-2.9.12-2hw4ddh7dbtl3wcw5hrt4kk2fkwhfuzj
-==> Installing libedit-3.1-20210216-3lzuqwnyuelfhjrxpn45akh7huu3ifr5
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libedit-3.1-20210216/linux-ubuntu18.04-x86_64-gcc-7.5.0-libedit-3.1-20210216-3lzuqwnyuelfhjrxpn45akh7huu3ifr5.spack
-==> Extracting libedit-3.1-20210216-3lzuqwnyuelfhjrxpn45akh7huu3ifr5 from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libedit-3.1-20210216-3lzuqwnyuelfhjrxpn45akh7huu3ifr5
-==> Installing readline-8.1-27u6g7pchcquj67llpfzttc6n7e5pfjg
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/readline-8.1/linux-ubuntu18.04-x86_64-gcc-7.5.0-readline-8.1-27u6g7pchcquj67llpfzttc6n7e5pfjg.spack
-==> Extracting readline-8.1-27u6g7pchcquj67llpfzttc6n7e5pfjg from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/readline-8.1-27u6g7pchcquj67llpfzttc6n7e5pfjg
-==> Installing bzip2-1.0.8-55rtzz4s6m4swr6x7exse22ucbmluwl3
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/bzip2-1.0.8/linux-ubuntu18.04-x86_64-gcc-7.5.0-bzip2-1.0.8-55rtzz4s6m4swr6x7exse22ucbmluwl3.spack
-==> Extracting bzip2-1.0.8-55rtzz4s6m4swr6x7exse22ucbmluwl3 from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/bzip2-1.0.8-55rtzz4s6m4swr6x7exse22ucbmluwl3
-==> Installing libtool-2.4.6-2kia6gf4yz6k3vsdqlg5lmp6n5hplrxq
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libtool-2.4.6/linux-ubuntu18.04-x86_64-gcc-7.5.0-libtool-2.4.6-2kia6gf4yz6k3vsdqlg5lmp6n5hplrxq.spack
-==> Extracting libtool-2.4.6-2kia6gf4yz6k3vsdqlg5lmp6n5hplrxq from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libtool-2.4.6-2kia6gf4yz6k3vsdqlg5lmp6n5hplrxq
-==> Installing gdbm-1.19-oftaepjelizkam37ezxwkuw27clnosqn
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/gdbm-1.19/linux-ubuntu18.04-x86_64-gcc-7.5.0-gdbm-1.19-oftaepjelizkam37ezxwkuw27clnosqn.spack
-==> Extracting gdbm-1.19-oftaepjelizkam37ezxwkuw27clnosqn from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/gdbm-1.19-oftaepjelizkam37ezxwkuw27clnosqn
-==> Installing libpciaccess-0.16-ryhmw2gqeeqclg65uuabqgsgpiac2nm2
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libpciaccess-0.16/linux-ubuntu18.04-x86_64-gcc-7.5.0-libpciaccess-0.16-ryhmw2gqeeqclg65uuabqgsgpiac2nm2.spack
-==> Extracting libpciaccess-0.16-ryhmw2gqeeqclg65uuabqgsgpiac2nm2 from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libpciaccess-0.16-ryhmw2gqeeqclg65uuabqgsgpiac2nm2
-==> Installing perl-5.34.0-672tzldkvypvrxirrs5okvjrfvhxzyzv
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.34.0/linux-ubuntu18.04-x86_64-gcc-7.5.0-perl-5.34.0-672tzldkvypvrxirrs5okvjrfvhxzyzv.spack
-==> Extracting perl-5.34.0-672tzldkvypvrxirrs5okvjrfvhxzyzv from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.34.0-672tzldkvypvrxirrs5okvjrfvhxzyzv
-==> Installing hwloc-2.6.0-gedgnpght7xquztmkhthmaid6lbhlz4p
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/hwloc-2.6.0/linux-ubuntu18.04-x86_64-gcc-7.5.0-hwloc-2.6.0-gedgnpght7xquztmkhthmaid6lbhlz4p.spack
-==> Extracting hwloc-2.6.0-gedgnpght7xquztmkhthmaid6lbhlz4p from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hwloc-2.6.0-gedgnpght7xquztmkhthmaid6lbhlz4p
-==> Installing openssl-1.1.1l-lygx3cqqbvl5gkyvfkggphorm7xus2ih
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssl-1.1.1l/linux-ubuntu18.04-x86_64-gcc-7.5.0-openssl-1.1.1l-lygx3cqqbvl5gkyvfkggphorm7xus2ih.spack
-==> Extracting openssl-1.1.1l-lygx3cqqbvl5gkyvfkggphorm7xus2ih from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssl-1.1.1l-lygx3cqqbvl5gkyvfkggphorm7xus2ih
-==> Installing autoconf-2.69-7hurwa7ymeksnawbazxutf7k7qvjm772
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/autoconf-2.69/linux-ubuntu18.04-x86_64-gcc-7.5.0-autoconf-2.69-7hurwa7ymeksnawbazxutf7k7qvjm772.spack
-==> Extracting autoconf-2.69-7hurwa7ymeksnawbazxutf7k7qvjm772 from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/autoconf-2.69-7hurwa7ymeksnawbazxutf7k7qvjm772
-==> Installing cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4/linux-ubuntu18.04-x86_64-gcc-7.5.0-cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea.spack
-==> Extracting cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea from binary cache
-==> Warning: patchelf --print-rpath /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea/share/cmake-3.21/Modules/Internal/CPack/CPack.OSXScriptLauncher.in produced an error [Command exited with status 1:
-    '/home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/patchelf-0.13-2txxradgazf7zvc5kzwmc26oqjuop7ej/bin/patchelf' '--print-rpath' '/home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea/share/cmake-3.21/Modules/Internal/CPack/CPack.OSXScriptLauncher.in'
-patchelf: not an ELF executable
-]
-==> Warning: patchelf --force-rpath --set-rpath /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea/share/cmake-3.21/Modules/Internal/CPack/CPack.OSXScriptLauncher.in failed with error Command exited with status 1:
-    '/home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/patchelf-0.13-2txxradgazf7zvc5kzwmc26oqjuop7ej/bin/patchelf' '--force-rpath' '--set-rpath' '' '/home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea/share/cmake-3.21/Modules/Internal/CPack/CPack.OSXScriptLauncher.in'
-patchelf: not an ELF executable
-
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.21.4-anj6kcxdxzhfufoypya56mmsmxlyucea
-==> Installing libevent-2.1.12-xai6pycqx4h6n2l7f676q3kwql5zjdaw
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libevent-2.1.12/linux-ubuntu18.04-x86_64-gcc-7.5.0-libevent-2.1.12-xai6pycqx4h6n2l7f676q3kwql5zjdaw.spack
-==> Extracting libevent-2.1.12-xai6pycqx4h6n2l7f676q3kwql5zjdaw from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libevent-2.1.12-xai6pycqx4h6n2l7f676q3kwql5zjdaw
-==> Installing openssh-8.7p1-ux36qlbxdga4c5oragb7o5r4y7bsgbpy
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssh-8.7p1/linux-ubuntu18.04-x86_64-gcc-7.5.0-openssh-8.7p1-ux36qlbxdga4c5oragb7o5r4y7bsgbpy.spack
-==> Extracting openssh-8.7p1-ux36qlbxdga4c5oragb7o5r4y7bsgbpy from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssh-8.7p1-ux36qlbxdga4c5oragb7o5r4y7bsgbpy
-==> Installing automake-1.16.3-6rqxcsn5r7kffecp45iumner6vnbbmho
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/automake-1.16.3/linux-ubuntu18.04-x86_64-gcc-7.5.0-automake-1.16.3-6rqxcsn5r7kffecp45iumner6vnbbmho.spack
-==> Extracting automake-1.16.3-6rqxcsn5r7kffecp45iumner6vnbbmho from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/automake-1.16.3-6rqxcsn5r7kffecp45iumner6vnbbmho
-==> Installing numactl-2.0.14-3opot4q2nxdmogm7t5pt5wkhvapqex76
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/numactl-2.0.14/linux-ubuntu18.04-x86_64-gcc-7.5.0-numactl-2.0.14-3opot4q2nxdmogm7t5pt5wkhvapqex76.spack
-==> Extracting numactl-2.0.14-3opot4q2nxdmogm7t5pt5wkhvapqex76 from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/numactl-2.0.14-3opot4q2nxdmogm7t5pt5wkhvapqex76
-==> Installing openmpi-4.1.1-p5qicacmcy72pjljd4lfdy66kavxp3tv
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/openmpi-4.1.1/linux-ubuntu18.04-x86_64-gcc-7.5.0-openmpi-4.1.1-p5qicacmcy72pjljd4lfdy66kavxp3tv.spack
-==> Extracting openmpi-4.1.1-p5qicacmcy72pjljd4lfdy66kavxp3tv from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openmpi-4.1.1-p5qicacmcy72pjljd4lfdy66kavxp3tv
-==> Installing hdf5-1.10.7-vt7sza3ycdsw62lk3f2dtnlvmeyihe3r
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.10.7/linux-ubuntu18.04-x86_64-gcc-7.5.0-hdf5-1.10.7-vt7sza3ycdsw62lk3f2dtnlvmeyihe3r.spack
-==> Extracting hdf5-1.10.7-vt7sza3ycdsw62lk3f2dtnlvmeyihe3r from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.10.7-vt7sza3ycdsw62lk3f2dtnlvmeyihe3r
+==> Waiting for pkgconf-1.8.0-i5po27g2n6zrzxnhxdy2fnpaai7xsdaw
+==> Installing pkgconf-1.8.0-i5po27g2n6zrzxnhxdy2fnpaai7xsdaw
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-pkgconf-1.8.0-i5po27g2n6zrzxnhxdy2fnpaai7xsdaw.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/pkgconf-1.8.0/linux-ubuntu18.04-x86_64-gcc-7.5.0-pkgconf-1.8.0-i5po27g2n6zrzxnhxdy2fnpaai7xsdaw.spack
+==> Extracting pkgconf-1.8.0-i5po27g2n6zrzxnhxdy2fnpaai7xsdaw from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/pkgconf-1.8.0-i5po27g2n6zrzxnhxdy2fnpaai7xsdaw
+==> Waiting for berkeley-db-18.1.40-q6tqmmmitkatscuadcwn6ea32iscs55k
+==> Installing berkeley-db-18.1.40-q6tqmmmitkatscuadcwn6ea32iscs55k
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-berkeley-db-18.1.40-q6tqmmmitkatscuadcwn6ea32iscs55k.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/berkeley-db-18.1.40/linux-ubuntu18.04-x86_64-gcc-7.5.0-berkeley-db-18.1.40-q6tqmmmitkatscuadcwn6ea32iscs55k.spack
+==> Extracting berkeley-db-18.1.40-q6tqmmmitkatscuadcwn6ea32iscs55k from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/berkeley-db-18.1.40-q6tqmmmitkatscuadcwn6ea32iscs55k
+==> Waiting for libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc
+==> Installing libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16/linux-ubuntu18.04-x86_64-gcc-7.5.0-libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc.spack
+==> Extracting libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc
+==> Waiting for zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs
+==> Installing zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.12/linux-ubuntu18.04-x86_64-gcc-7.5.0-zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs.spack
+==> Extracting zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs
+==> Waiting for libsigsegv-2.13-ubezeychw4iojr3tg6wbsnvp6s3s2qwd
+==> Installing libsigsegv-2.13-ubezeychw4iojr3tg6wbsnvp6s3s2qwd
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-libsigsegv-2.13-ubezeychw4iojr3tg6wbsnvp6s3s2qwd.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libsigsegv-2.13/linux-ubuntu18.04-x86_64-gcc-7.5.0-libsigsegv-2.13-ubezeychw4iojr3tg6wbsnvp6s3s2qwd.spack
+==> Extracting libsigsegv-2.13-ubezeychw4iojr3tg6wbsnvp6s3s2qwd from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libsigsegv-2.13-ubezeychw4iojr3tg6wbsnvp6s3s2qwd
+==> Waiting for util-macros-1.19.3-vkk73ww5p7g4u6lpnay5hcclsckcihtt
+==> Installing util-macros-1.19.3-vkk73ww5p7g4u6lpnay5hcclsckcihtt
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-util-macros-1.19.3-vkk73ww5p7g4u6lpnay5hcclsckcihtt.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/util-macros-1.19.3/linux-ubuntu18.04-x86_64-gcc-7.5.0-util-macros-1.19.3-vkk73ww5p7g4u6lpnay5hcclsckcihtt.spack
+==> Extracting util-macros-1.19.3-vkk73ww5p7g4u6lpnay5hcclsckcihtt from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/util-macros-1.19.3-vkk73ww5p7g4u6lpnay5hcclsckcihtt
+==> Waiting for xz-5.2.5-olptpbsse74hpreilbfo4qmlqexihzye
+==> Installing xz-5.2.5-olptpbsse74hpreilbfo4qmlqexihzye
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-xz-5.2.5-olptpbsse74hpreilbfo4qmlqexihzye.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/xz-5.2.5/linux-ubuntu18.04-x86_64-gcc-7.5.0-xz-5.2.5-olptpbsse74hpreilbfo4qmlqexihzye.spack
+==> Extracting xz-5.2.5-olptpbsse74hpreilbfo4qmlqexihzye from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/xz-5.2.5-olptpbsse74hpreilbfo4qmlqexihzye
+==> Waiting for ncurses-6.2-frwzsc4jrou7efe7huyzeownqfjvsrfd
+==> Installing ncurses-6.2-frwzsc4jrou7efe7huyzeownqfjvsrfd
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-ncurses-6.2-frwzsc4jrou7efe7huyzeownqfjvsrfd.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/ncurses-6.2/linux-ubuntu18.04-x86_64-gcc-7.5.0-ncurses-6.2-frwzsc4jrou7efe7huyzeownqfjvsrfd.spack
+==> Extracting ncurses-6.2-frwzsc4jrou7efe7huyzeownqfjvsrfd from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/ncurses-6.2-frwzsc4jrou7efe7huyzeownqfjvsrfd
+==> Waiting for diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
+==> Installing diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/diffutils-3.8/linux-ubuntu18.04-x86_64-gcc-7.5.0-diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq.spack
+==> Extracting diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
+==> Waiting for m4-1.4.19-uadbn2a64h744jto2xqy6u2wmujcww6v
+==> Installing m4-1.4.19-uadbn2a64h744jto2xqy6u2wmujcww6v
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-m4-1.4.19-uadbn2a64h744jto2xqy6u2wmujcww6v.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/m4-1.4.19/linux-ubuntu18.04-x86_64-gcc-7.5.0-m4-1.4.19-uadbn2a64h744jto2xqy6u2wmujcww6v.spack
+==> Extracting m4-1.4.19-uadbn2a64h744jto2xqy6u2wmujcww6v from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/m4-1.4.19-uadbn2a64h744jto2xqy6u2wmujcww6v
+==> Waiting for libxml2-2.9.13-4run532u4c6iy5th5gkpgm26tr4vajc4
+==> Installing libxml2-2.9.13-4run532u4c6iy5th5gkpgm26tr4vajc4
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-libxml2-2.9.13-4run532u4c6iy5th5gkpgm26tr4vajc4.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libxml2-2.9.13/linux-ubuntu18.04-x86_64-gcc-7.5.0-libxml2-2.9.13-4run532u4c6iy5th5gkpgm26tr4vajc4.spack
+==> Extracting libxml2-2.9.13-4run532u4c6iy5th5gkpgm26tr4vajc4 from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libxml2-2.9.13-4run532u4c6iy5th5gkpgm26tr4vajc4
+==> Waiting for libedit-3.1-20210216-zc56lv6gyjpfvi4tpdtmx5yb7ljfnlrb
+==> Installing libedit-3.1-20210216-zc56lv6gyjpfvi4tpdtmx5yb7ljfnlrb
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-libedit-3.1-20210216-zc56lv6gyjpfvi4tpdtmx5yb7ljfnlrb.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libedit-3.1-20210216/linux-ubuntu18.04-x86_64-gcc-7.5.0-libedit-3.1-20210216-zc56lv6gyjpfvi4tpdtmx5yb7ljfnlrb.spack
+==> Extracting libedit-3.1-20210216-zc56lv6gyjpfvi4tpdtmx5yb7ljfnlrb from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libedit-3.1-20210216-zc56lv6gyjpfvi4tpdtmx5yb7ljfnlrb
+==> Waiting for readline-8.1-ls6erxwsj2ubsfzt4x5mblj6nrab5jkp
+==> Installing readline-8.1-ls6erxwsj2ubsfzt4x5mblj6nrab5jkp
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-readline-8.1-ls6erxwsj2ubsfzt4x5mblj6nrab5jkp.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/readline-8.1/linux-ubuntu18.04-x86_64-gcc-7.5.0-readline-8.1-ls6erxwsj2ubsfzt4x5mblj6nrab5jkp.spack
+==> Extracting readline-8.1-ls6erxwsj2ubsfzt4x5mblj6nrab5jkp from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/readline-8.1-ls6erxwsj2ubsfzt4x5mblj6nrab5jkp
+==> Waiting for bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
+==> Installing bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/bzip2-1.0.8/linux-ubuntu18.04-x86_64-gcc-7.5.0-bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f.spack
+==> Extracting bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
+==> Waiting for libtool-2.4.7-7fhdrxxizepvvkxrfaaizhzkwx2sjzbt
+==> Installing libtool-2.4.7-7fhdrxxizepvvkxrfaaizhzkwx2sjzbt
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-libtool-2.4.7-7fhdrxxizepvvkxrfaaizhzkwx2sjzbt.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libtool-2.4.7/linux-ubuntu18.04-x86_64-gcc-7.5.0-libtool-2.4.7-7fhdrxxizepvvkxrfaaizhzkwx2sjzbt.spack
+==> Extracting libtool-2.4.7-7fhdrxxizepvvkxrfaaizhzkwx2sjzbt from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libtool-2.4.7-7fhdrxxizepvvkxrfaaizhzkwx2sjzbt
+==> Waiting for gdbm-1.19-xub4jsy5pz5qjf6vooropf2shkigy5pm
+==> Installing gdbm-1.19-xub4jsy5pz5qjf6vooropf2shkigy5pm
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-gdbm-1.19-xub4jsy5pz5qjf6vooropf2shkigy5pm.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/gdbm-1.19/linux-ubuntu18.04-x86_64-gcc-7.5.0-gdbm-1.19-xub4jsy5pz5qjf6vooropf2shkigy5pm.spack
+==> Extracting gdbm-1.19-xub4jsy5pz5qjf6vooropf2shkigy5pm from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/gdbm-1.19-xub4jsy5pz5qjf6vooropf2shkigy5pm
+==> Waiting for libpciaccess-0.16-csp5gvqmwcmqsd4al5iafotfk5fqh3uf
+==> Installing libpciaccess-0.16-csp5gvqmwcmqsd4al5iafotfk5fqh3uf
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-libpciaccess-0.16-csp5gvqmwcmqsd4al5iafotfk5fqh3uf.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libpciaccess-0.16/linux-ubuntu18.04-x86_64-gcc-7.5.0-libpciaccess-0.16-csp5gvqmwcmqsd4al5iafotfk5fqh3uf.spack
+==> Extracting libpciaccess-0.16-csp5gvqmwcmqsd4al5iafotfk5fqh3uf from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libpciaccess-0.16-csp5gvqmwcmqsd4al5iafotfk5fqh3uf
+==> Waiting for perl-5.34.1-pn5mteswujdkuong6mbqaush54rdas7c
+==> Installing perl-5.34.1-pn5mteswujdkuong6mbqaush54rdas7c
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-perl-5.34.1-pn5mteswujdkuong6mbqaush54rdas7c.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.34.1/linux-ubuntu18.04-x86_64-gcc-7.5.0-perl-5.34.1-pn5mteswujdkuong6mbqaush54rdas7c.spack
+==> Extracting perl-5.34.1-pn5mteswujdkuong6mbqaush54rdas7c from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/perl-5.34.1-pn5mteswujdkuong6mbqaush54rdas7c
+==> Waiting for hwloc-2.7.1-oixja6dnsnc4mydqswdya2nyt4rlcxpa
+==> Installing hwloc-2.7.1-oixja6dnsnc4mydqswdya2nyt4rlcxpa
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-hwloc-2.7.1-oixja6dnsnc4mydqswdya2nyt4rlcxpa.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/hwloc-2.7.1/linux-ubuntu18.04-x86_64-gcc-7.5.0-hwloc-2.7.1-oixja6dnsnc4mydqswdya2nyt4rlcxpa.spack
+==> Extracting hwloc-2.7.1-oixja6dnsnc4mydqswdya2nyt4rlcxpa from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hwloc-2.7.1-oixja6dnsnc4mydqswdya2nyt4rlcxpa
+==> Waiting for autoconf-2.69-hlj3ujmrsu5gs7uhfdotozzg6ipys45b
+==> Installing autoconf-2.69-hlj3ujmrsu5gs7uhfdotozzg6ipys45b
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-autoconf-2.69-hlj3ujmrsu5gs7uhfdotozzg6ipys45b.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/autoconf-2.69/linux-ubuntu18.04-x86_64-gcc-7.5.0-autoconf-2.69-hlj3ujmrsu5gs7uhfdotozzg6ipys45b.spack
+==> Extracting autoconf-2.69-hlj3ujmrsu5gs7uhfdotozzg6ipys45b from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/autoconf-2.69-hlj3ujmrsu5gs7uhfdotozzg6ipys45b
+==> Waiting for openssl-1.1.1o-hqlqpsnqoifap6mlkbr5fyxoaq3gynbk
+==> Installing openssl-1.1.1o-hqlqpsnqoifap6mlkbr5fyxoaq3gynbk
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-openssl-1.1.1o-hqlqpsnqoifap6mlkbr5fyxoaq3gynbk.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssl-1.1.1o/linux-ubuntu18.04-x86_64-gcc-7.5.0-openssl-1.1.1o-hqlqpsnqoifap6mlkbr5fyxoaq3gynbk.spack
+==> Extracting openssl-1.1.1o-hqlqpsnqoifap6mlkbr5fyxoaq3gynbk from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssl-1.1.1o-hqlqpsnqoifap6mlkbr5fyxoaq3gynbk
+==> Waiting for automake-1.16.5-6vk5ehdtjzgcvug6vuwh2mmkjhg2pn2z
+==> Installing automake-1.16.5-6vk5ehdtjzgcvug6vuwh2mmkjhg2pn2z
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-automake-1.16.5-6vk5ehdtjzgcvug6vuwh2mmkjhg2pn2z.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/automake-1.16.5/linux-ubuntu18.04-x86_64-gcc-7.5.0-automake-1.16.5-6vk5ehdtjzgcvug6vuwh2mmkjhg2pn2z.spack
+==> Extracting automake-1.16.5-6vk5ehdtjzgcvug6vuwh2mmkjhg2pn2z from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/automake-1.16.5-6vk5ehdtjzgcvug6vuwh2mmkjhg2pn2z
+==> Waiting for libevent-2.1.12-hlnkgmrdcycqf65n6vrvoraq4dhddagv
+==> Installing libevent-2.1.12-hlnkgmrdcycqf65n6vrvoraq4dhddagv
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-libevent-2.1.12-hlnkgmrdcycqf65n6vrvoraq4dhddagv.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/libevent-2.1.12/linux-ubuntu18.04-x86_64-gcc-7.5.0-libevent-2.1.12-hlnkgmrdcycqf65n6vrvoraq4dhddagv.spack
+==> Extracting libevent-2.1.12-hlnkgmrdcycqf65n6vrvoraq4dhddagv from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/libevent-2.1.12-hlnkgmrdcycqf65n6vrvoraq4dhddagv
+==> Waiting for openssh-9.0p1-3ez3d3jtc4f7bph5suuzqebujp3gppwv
+==> Installing openssh-9.0p1-3ez3d3jtc4f7bph5suuzqebujp3gppwv
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-openssh-9.0p1-3ez3d3jtc4f7bph5suuzqebujp3gppwv.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssh-9.0p1/linux-ubuntu18.04-x86_64-gcc-7.5.0-openssh-9.0p1-3ez3d3jtc4f7bph5suuzqebujp3gppwv.spack
+==> Extracting openssh-9.0p1-3ez3d3jtc4f7bph5suuzqebujp3gppwv from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openssh-9.0p1-3ez3d3jtc4f7bph5suuzqebujp3gppwv
+==> Waiting for cmake-3.23.1-tulqz4nxor764kgeij23tfap4ddgpgvh
+==> Installing cmake-3.23.1-tulqz4nxor764kgeij23tfap4ddgpgvh
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-cmake-3.23.1-tulqz4nxor764kgeij23tfap4ddgpgvh.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.23.1/linux-ubuntu18.04-x86_64-gcc-7.5.0-cmake-3.23.1-tulqz4nxor764kgeij23tfap4ddgpgvh.spack
+==> Extracting cmake-3.23.1-tulqz4nxor764kgeij23tfap4ddgpgvh from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/cmake-3.23.1-tulqz4nxor764kgeij23tfap4ddgpgvh
+==> Waiting for numactl-2.0.14-wfnw532l74emh6rwx4mrvot3huyiq53t
+==> Installing numactl-2.0.14-wfnw532l74emh6rwx4mrvot3huyiq53t
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-numactl-2.0.14-wfnw532l74emh6rwx4mrvot3huyiq53t.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/numactl-2.0.14/linux-ubuntu18.04-x86_64-gcc-7.5.0-numactl-2.0.14-wfnw532l74emh6rwx4mrvot3huyiq53t.spack
+==> Extracting numactl-2.0.14-wfnw532l74emh6rwx4mrvot3huyiq53t from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/numactl-2.0.14-wfnw532l74emh6rwx4mrvot3huyiq53t
+==> Waiting for pmix-4.1.2-e4fax4744gqg222snd6da55c3xq3zu34
+==> Installing pmix-4.1.2-e4fax4744gqg222snd6da55c3xq3zu34
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-pmix-4.1.2-e4fax4744gqg222snd6da55c3xq3zu34.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/pmix-4.1.2/linux-ubuntu18.04-x86_64-gcc-7.5.0-pmix-4.1.2-e4fax4744gqg222snd6da55c3xq3zu34.spack
+==> Extracting pmix-4.1.2-e4fax4744gqg222snd6da55c3xq3zu34 from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/pmix-4.1.2-e4fax4744gqg222snd6da55c3xq3zu34
+==> Waiting for openmpi-4.1.3-jfxctqwar7wb65rn7wf5mot7m4jxmsey
+==> Installing openmpi-4.1.3-jfxctqwar7wb65rn7wf5mot7m4jxmsey
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-openmpi-4.1.3-jfxctqwar7wb65rn7wf5mot7m4jxmsey.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/openmpi-4.1.3/linux-ubuntu18.04-x86_64-gcc-7.5.0-openmpi-4.1.3-jfxctqwar7wb65rn7wf5mot7m4jxmsey.spack
+==> Extracting openmpi-4.1.3-jfxctqwar7wb65rn7wf5mot7m4jxmsey from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/openmpi-4.1.3-jfxctqwar7wb65rn7wf5mot7m4jxmsey
+==> Waiting for hdf5-1.12.2-rh2gilz6xlosoeuldxtgeyz65wsualsj
+==> Installing hdf5-1.12.2-rh2gilz6xlosoeuldxtgeyz65wsualsj
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-hdf5-1.12.2-rh2gilz6xlosoeuldxtgeyz65wsualsj.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.12.2/linux-ubuntu18.04-x86_64-gcc-7.5.0-hdf5-1.12.2-rh2gilz6xlosoeuldxtgeyz65wsualsj.spack
+==> Extracting hdf5-1.12.2-rh2gilz6xlosoeuldxtgeyz65wsualsj from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/hdf5-1.12.2-rh2gilz6xlosoeuldxtgeyz65wsualsj
 $ spack install zlib%clang
-==> Installing zlib-1.2.11-atdrszvduszjw55p5g7fnjezpb5l6veu
-==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/clang-7.0.0/zlib-1.2.11/linux-ubuntu18.04-x86_64-clang-7.0.0-zlib-1.2.11-atdrszvduszjw55p5g7fnjezpb5l6veu.spack
-==> Extracting zlib-1.2.11-atdrszvduszjw55p5g7fnjezpb5l6veu from binary cache
-[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/clang-7.0.0/zlib-1.2.11-atdrszvduszjw55p5g7fnjezpb5l6veu
+==> Waiting for zlib-1.2.12-3svypjaie5farii5zcgm6yfu43la2ixs
+==> Installing zlib-1.2.12-3svypjaie5farii5zcgm6yfu43la2ixs
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-clang-7.0.0-zlib-1.2.12-3svypjaie5farii5zcgm6yfu43la2ixs.spec.json.sig
+==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/clang-7.0.0/zlib-1.2.12/linux-ubuntu18.04-x86_64-clang-7.0.0-zlib-1.2.12-3svypjaie5farii5zcgm6yfu43la2ixs.spack
+==> Extracting zlib-1.2.12-3svypjaie5farii5zcgm6yfu43la2ixs from binary cache
+[+] /home/spack/spack/opt/spack/linux-ubuntu18.04-x86_64/clang-7.0.0/zlib-1.2.12-3svypjaie5farii5zcgm6yfu43la2ixs

--- a/outputs/scripting/spack-python-1.out
+++ b/outputs/scripting/spack-python-1.out
@@ -1,5 +1,6 @@
 $ spack python
+exit()
 
-Spack version 0.17.0
+Spack version 0.18.0
 Python 3.6.9, Linux x86_64
 >>> exit()


### PR DESCRIPTION
Rerun the scripting tutorial with Spack 0.18

I also included an edit to the makefile here so running `make` in `outputs/` will filter terminal control codes from `raw/*.out` files.