### PR TITLE
Update/v18 caching tutorial

### DIFF
--- a/outputs/cache.sh
+++ b/outputs/cache.sh
@@ -10,7 +10,7 @@ pip install boto3
 example cache/up-to-date "git clone https://github.com/spack/spack ~/spack"
 example cache/up-to-date "cd ~/spack"
 cd ~/spack
-example cache/up-to-date "git checkout releases/v0.17"
+example cache/up-to-date "git checkout releases/v0.18"
 example cache/up-to-date ". share/spack/setup-env.sh"
 . share/spack/setup-env.sh
 spack config add "config:suppress_gpg_warnings:true"
@@ -68,7 +68,7 @@ example cache/binary-cache-1 "spack add bzip2"
 example cache/binary-cache-1 "spack add zlib"
 
 example cache/binary-cache-2 'spack config add "config:install_tree:padded_length:128"'
-example cache/binary-cache-2 "spack install --no-cache"
+example cache/binary-cache-2 "spack install --fresh --no-cache"
 
 example cache/binary-cache-3 'spack gpg create "My Name" "<my.email@my.domain.com>"'
 

--- a/outputs/cache.sh
+++ b/outputs/cache.sh
@@ -53,7 +53,6 @@ example cache/spack-mirror-3 "spack install"
 
 example cache/spack-mirror-4 "spack mirror create -d ~/mirror --all"
 
-
 example cache/trust "spack buildcache keys --install --trust --force"
 
 example cache/binary-cache-1 "cd ~"
@@ -68,7 +67,7 @@ example cache/binary-cache-1 "spack add bzip2"
 example cache/binary-cache-1 "spack add zlib"
 
 example cache/binary-cache-2 'spack config add "config:install_tree:padded_length:128"'
-example cache/binary-cache-2 "spack install --fresh --no-cache"
+example cache/binary-cache-2 "spack install --no-cache"
 
 example cache/binary-cache-3 'spack gpg create "My Name" "<my.email@my.domain.com>"'
 
@@ -84,3 +83,6 @@ for ii in $(spack find --format "yyy {version} /{hash}" |
 do
   spack buildcache create --allow-root --force -d ~/mirror --only=package $ii
 done'
+
+# Remove installations from customized prefix
+spack uninstall -ay

--- a/outputs/cache/binary-cache-2.out
+++ b/outputs/cache/binary-cache-2.out
@@ -1,14 +1,14 @@
 $ spack config add "config:install_tree:padded_length:128"
-$ spack install --fresh --no-cache
+$ spack install --no-cache
 ==> Starting concretization pool with 2 processes
-==> Environment concretized in 0.53 seconds.
+==> Environment concretized in 1.23 seconds.
 ==> Concretized bzip2
  -   cyn2yam  bzip2@1.0.8%gcc@7.5.0~debug~pic+shared arch=linux-ubuntu18.04-x86_64
  -   k22pe4r	  ^diffutils@3.8%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
  -   dr56jt4	      ^libiconv@1.16%gcc@7.5.0 libs=shared,static arch=linux-ubuntu18.04-x86_64
 
 ==> Concretized zlib
-[+]  fntvsj6  zlib@1.2.12%gcc@7.5.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu18.04-x86_64
+ -   fntvsj6  zlib@1.2.12%gcc@7.5.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu18.04-x86_64
 
 ==> Installing environment /home/spack/cache-binary
 ==> Waiting for libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc
@@ -20,8 +20,16 @@ $ spack install --fresh --no-cache
 ==> libiconv: Executing phase: 'build'
 ==> libiconv: Executing phase: 'install'
 ==> libiconv: Successfully installed libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc
-  Fetch: 0.05s.  Build: 23.65s.  Total: 23.70s.
+  Fetch: 0.02s.  Build: 22.62s.  Total: 22.64s.
 [+] /home/spack/spack/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc
+==> Waiting for zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs
+==> Installing zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs
+==> Using cached archive: /home/spack/spack/var/spack/cache/_source-cache/archive/91/91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9.tar.gz
+==> Applied patch /home/spack/spack/var/spack/repos/builtin/packages/zlib/configure-cc.patch
+==> zlib: Executing phase: 'install'
+==> zlib: Successfully installed zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs
+  Fetch: 0.01s.  Build: 3.88s.	Total: 3.89s.
+[+] /home/spack/spack/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs
 ==> Waiting for diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
 ==> Installing diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
 ==> Using cached archive: /home/spack/spack/var/spack/cache/_source-cache/archive/a6/a6bdd7d1b31266d11c4f4de6c1b748d4607ab0231af5188fc2533d0ae2438fec.tar.xz
@@ -31,7 +39,7 @@ $ spack install --fresh --no-cache
 ==> diffutils: Executing phase: 'build'
 ==> diffutils: Executing phase: 'install'
 ==> diffutils: Successfully installed diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
-  Fetch: 0.01s.  Build: 33.62s.  Total: 33.63s.
+  Fetch: 0.01s.  Build: 31.62s.  Total: 31.63s.
 [+] /home/spack/spack/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-ubuntu18.04-x86_64/gcc-7.5.0/diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
 ==> Waiting for bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
 ==> Installing bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
@@ -39,6 +47,6 @@ $ spack install --fresh --no-cache
 ==> Ran patch() for bzip2
 ==> bzip2: Executing phase: 'install'
 ==> bzip2: Successfully installed bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
-  Fetch: 0.01s.  Build: 2.40s.	Total: 2.40s.
+  Fetch: 0.01s.  Build: 2.18s.	Total: 2.19s.
 [+] /home/spack/spack/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-ubuntu18.04-x86_64/gcc-7.5.0/bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
 ==> Updating view at /home/spack/cache-binary/.spack-env/view

--- a/outputs/cache/binary-cache-2.out
+++ b/outputs/cache/binary-cache-2.out
@@ -1,48 +1,44 @@
 $ spack config add "config:install_tree:padded_length:128"
-$ spack install --no-cache
+$ spack install --fresh --no-cache
 ==> Starting concretization pool with 2 processes
-==> Environment concretized in 1.62 seconds.
+==> Environment concretized in 0.53 seconds.
 ==> Concretized bzip2
  -   cyn2yam  bzip2@1.0.8%gcc@7.5.0~debug~pic+shared arch=linux-ubuntu18.04-x86_64
  -   k22pe4r	  ^diffutils@3.8%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
  -   dr56jt4	      ^libiconv@1.16%gcc@7.5.0 libs=shared,static arch=linux-ubuntu18.04-x86_64
 
 ==> Concretized zlib
- -   fntvsj6  zlib@1.2.12%gcc@7.5.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu18.04-x86_64
+[+]  fntvsj6  zlib@1.2.12%gcc@7.5.0+optimize+pic+shared patches=0d38234 arch=linux-ubuntu18.04-x86_64
 
 ==> Installing environment /home/spack/cache-binary
+==> Waiting for libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc
 ==> Installing libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc
-==> Fetching https://mirror.spack.io/_source-cache/archive/e6/e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04.tar.gz
+==> Using cached archive: /home/spack/spack/var/spack/cache/_source-cache/archive/e6/e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04.tar.gz
 ==> No patches needed for libiconv
 ==> libiconv: Executing phase: 'autoreconf'
 ==> libiconv: Executing phase: 'configure'
 ==> libiconv: Executing phase: 'build'
 ==> libiconv: Executing phase: 'install'
 ==> libiconv: Successfully installed libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc
-  Fetch: 8.83s.  Build: 25.35s.  Total: 34.19s.
+  Fetch: 0.05s.  Build: 23.65s.  Total: 23.70s.
 [+] /home/spack/spack/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-ubuntu18.04-x86_64/gcc-7.5.0/libiconv-1.16-dr56jt456uiebij2mkueldmejdxftigc
-==> Installing zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs
-==> Fetching https://mirror.spack.io/_source-cache/archive/91/91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9.tar.gz
-==> Applied patch /home/spack/spack/var/spack/repos/builtin/packages/zlib/configure-cc.patch
-==> zlib: Executing phase: 'install'
-==> zlib: Successfully installed zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs
-  Fetch: 2.71s.  Build: 1.71s.	Total: 4.42s.
-[+] /home/spack/spack/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.12-fntvsj6xevbz5gyq7kfa4xg7oxnaolxs
+==> Waiting for diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
 ==> Installing diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
-==> Fetching https://mirror.spack.io/_source-cache/archive/a6/a6bdd7d1b31266d11c4f4de6c1b748d4607ab0231af5188fc2533d0ae2438fec.tar.xz
+==> Using cached archive: /home/spack/spack/var/spack/cache/_source-cache/archive/a6/a6bdd7d1b31266d11c4f4de6c1b748d4607ab0231af5188fc2533d0ae2438fec.tar.xz
 ==> No patches needed for diffutils
 ==> diffutils: Executing phase: 'autoreconf'
 ==> diffutils: Executing phase: 'configure'
 ==> diffutils: Executing phase: 'build'
 ==> diffutils: Executing phase: 'install'
 ==> diffutils: Successfully installed diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
-  Fetch: 2.88s.  Build: 38.71s.  Total: 41.59s.
+  Fetch: 0.01s.  Build: 33.62s.  Total: 33.63s.
 [+] /home/spack/spack/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-ubuntu18.04-x86_64/gcc-7.5.0/diffutils-3.8-k22pe4rhr7yllf5pojl75veh5gkjdglq
+==> Waiting for bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
 ==> Installing bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
-==> Fetching https://mirror.spack.io/_source-cache/archive/ab/ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269.tar.gz
+==> Using cached archive: /home/spack/spack/var/spack/cache/_source-cache/archive/ab/ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269.tar.gz
 ==> Ran patch() for bzip2
 ==> bzip2: Executing phase: 'install'
 ==> bzip2: Successfully installed bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
-  Fetch: 2.79s.  Build: 1.88s.	Total: 4.67s.
+  Fetch: 0.01s.  Build: 2.40s.	Total: 2.40s.
 [+] /home/spack/spack/opt/spack/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeholder__/__spack_path_placeh/linux-ubuntu18.04-x86_64/gcc-7.5.0/bzip2-1.0.8-cyn2yamiu26ofxwgxzxbioreuwigzl6f
 ==> Updating view at /home/spack/cache-binary/.spack-env/view

--- a/outputs/cache/binary-cache-3.out
+++ b/outputs/cache/binary-cache-3.out
@@ -1,7 +1,7 @@
 $ spack gpg create "My Name" "<my.email@my.domain.com>"
-gpg: key 7AF0A74FC3AEAD1A marked as ultimately trusted
+gpg: key 17C89019332153B3 marked as ultimately trusted
 gpg: directory '/home/spack/spack/opt/spack/gpg/openpgp-revocs.d' created
-gpg: revocation certificate stored as '/home/spack/spack/opt/spack/gpg/openpgp-revocs.d/B1F6BF0C8E83699276A2093A7AF0A74FC3AEAD1A.rev'
+gpg: revocation certificate stored as '/home/spack/spack/opt/spack/gpg/openpgp-revocs.d/6CD3E56434535E8EDCA1C0C017C89019332153B3.rev'
 $ mkdir ~/private_gpg_backup
 $ cp ~/spack/opt/spack/gpg/*.gpg ~/private_gpg_backup
 $ cp ~/spack/opt/spack/gpg/pubring.* ~/mirror

--- a/outputs/cache/binary-cache-3.out
+++ b/outputs/cache/binary-cache-3.out
@@ -1,7 +1,7 @@
 $ spack gpg create "My Name" "<my.email@my.domain.com>"
-gpg: key 17C89019332153B3 marked as ultimately trusted
+gpg: key 718DD98D63235873 marked as ultimately trusted
 gpg: directory '/home/spack/spack/opt/spack/gpg/openpgp-revocs.d' created
-gpg: revocation certificate stored as '/home/spack/spack/opt/spack/gpg/openpgp-revocs.d/6CD3E56434535E8EDCA1C0C017C89019332153B3.rev'
+gpg: revocation certificate stored as '/home/spack/spack/opt/spack/gpg/openpgp-revocs.d/A74BD2559C7EAFFF1B48ECAC718DD98D63235873.rev'
 $ mkdir ~/private_gpg_backup
 $ cp ~/spack/opt/spack/gpg/*.gpg ~/private_gpg_backup
 $ cp ~/spack/opt/spack/gpg/pubring.* ~/mirror

--- a/outputs/cache/binary-cache-4.out
+++ b/outputs/cache/binary-cache-4.out
@@ -10,10 +10,10 @@ done
 gpg: checking the trustdb
 gpg: marginals needed: 3  completes needed: 1  trust model: pgp
 gpg: depth: 0  valid:	2  signed:   0	trust: 0-, 0q, 0n, 0m, 0f, 2u
-gpg: using "B1F6BF0C8E83699276A2093A7AF0A74FC3AEAD1A" as default secret key for signing
+gpg: using "6CD3E56434535E8EDCA1C0C017C89019332153B3" as default secret key for signing
 ==> Pushing binary packages to file:///home/spack/mirror/build_cache
-gpg: using "B1F6BF0C8E83699276A2093A7AF0A74FC3AEAD1A" as default secret key for signing
+gpg: using "6CD3E56434535E8EDCA1C0C017C89019332153B3" as default secret key for signing
 ==> Pushing binary packages to file:///home/spack/mirror/build_cache
-gpg: using "B1F6BF0C8E83699276A2093A7AF0A74FC3AEAD1A" as default secret key for signing
+gpg: using "6CD3E56434535E8EDCA1C0C017C89019332153B3" as default secret key for signing
 ==> Pushing binary packages to file:///home/spack/mirror/build_cache
-gpg: using "B1F6BF0C8E83699276A2093A7AF0A74FC3AEAD1A" as default secret key for signing
+gpg: using "6CD3E56434535E8EDCA1C0C017C89019332153B3" as default secret key for signing

--- a/outputs/cache/binary-cache-4.out
+++ b/outputs/cache/binary-cache-4.out
@@ -10,10 +10,10 @@ done
 gpg: checking the trustdb
 gpg: marginals needed: 3  completes needed: 1  trust model: pgp
 gpg: depth: 0  valid:	2  signed:   0	trust: 0-, 0q, 0n, 0m, 0f, 2u
-gpg: using "6CD3E56434535E8EDCA1C0C017C89019332153B3" as default secret key for signing
+gpg: using "A74BD2559C7EAFFF1B48ECAC718DD98D63235873" as default secret key for signing
 ==> Pushing binary packages to file:///home/spack/mirror/build_cache
-gpg: using "6CD3E56434535E8EDCA1C0C017C89019332153B3" as default secret key for signing
+gpg: using "A74BD2559C7EAFFF1B48ECAC718DD98D63235873" as default secret key for signing
 ==> Pushing binary packages to file:///home/spack/mirror/build_cache
-gpg: using "6CD3E56434535E8EDCA1C0C017C89019332153B3" as default secret key for signing
+gpg: using "A74BD2559C7EAFFF1B48ECAC718DD98D63235873" as default secret key for signing
 ==> Pushing binary packages to file:///home/spack/mirror/build_cache
-gpg: using "6CD3E56434535E8EDCA1C0C017C89019332153B3" as default secret key for signing
+gpg: using "A74BD2559C7EAFFF1B48ECAC718DD98D63235873" as default secret key for signing

--- a/outputs/cache/mirror-list-0.out
+++ b/outputs/cache/mirror-list-0.out
@@ -1,4 +1,3 @@
 $ spack mirror list
-tutorial	file:///mirror (fetch)
-tutorial	file:///mirror (push)
+tutorial	file:///mirror
 spack-public	https://mirror.spack.io

--- a/outputs/cache/setup-scr.out
+++ b/outputs/cache/setup-scr.out
@@ -12,7 +12,7 @@ $ spack add macsio+scr
 ==> Adding macsio+scr to environment /home/spack/cache-env
 $ spack install
 ==> Starting concretization
-==> Environment concretized in 20.92 seconds.
+==> Environment concretized in 21.00 seconds.
 ==> Concretized macsio+scr
 [+]  c5sjc2l  macsio@1.1%gcc@7.5.0~exodus~hdf5~ipo+mpi~pdb+scr+silo~szip~typhonio~zfp~zlib build_type=RelWithDebInfo patches=59479b9 arch=linux-ubuntu18.04-x86_64
 [+]  tulqz4n	  ^cmake@3.23.1%gcc@7.5.0~doc+ncurses+ownlibs~qt build_type=Release arch=linux-ubuntu18.04-x86_64

--- a/outputs/cache/setup-scr.out
+++ b/outputs/cache/setup-scr.out
@@ -12,7 +12,7 @@ $ spack add macsio+scr
 ==> Adding macsio+scr to environment /home/spack/cache-env
 $ spack install
 ==> Starting concretization
-==> Environment concretized in 18.00 seconds.
+==> Environment concretized in 20.92 seconds.
 ==> Concretized macsio+scr
 [+]  c5sjc2l  macsio@1.1%gcc@7.5.0~exodus~hdf5~ipo+mpi~pdb+scr+silo~szip~typhonio~zfp~zlib build_type=RelWithDebInfo patches=59479b9 arch=linux-ubuntu18.04-x86_64
 [+]  tulqz4n	  ^cmake@3.23.1%gcc@7.5.0~doc+ncurses+ownlibs~qt build_type=Release arch=linux-ubuntu18.04-x86_64

--- a/outputs/cache/spack-mirror-3.out
+++ b/outputs/cache/spack-mirror-3.out
@@ -2,7 +2,7 @@ $ spack add unzip
 ==> Adding unzip to environment /home/spack/cache-env
 $ spack install
 ==> Starting concretization
-==> Environment concretized in 1.31 seconds.
+==> Environment concretized in 0.82 seconds.
 ==> Concretized macsio+scr
 [+]  c5sjc2l  macsio@1.1%gcc@7.5.0~exodus~hdf5~ipo+mpi~pdb+scr+silo~szip~typhonio~zfp~zlib build_type=RelWithDebInfo patches=59479b9 arch=linux-ubuntu18.04-x86_64
 [+]  tulqz4n	  ^cmake@3.23.1%gcc@7.5.0~doc+ncurses+ownlibs~qt build_type=Release arch=linux-ubuntu18.04-x86_64
@@ -76,6 +76,7 @@ $ spack install
  -   qos6nfh  unzip@6.0%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
 
 ==> Installing environment /home/spack/cache-env
+==> Waiting for unzip-6.0-qos6nfhjj5mdkrpwqrpb3hl6n5wi3woj
 ==> Installing unzip-6.0-qos6nfhjj5mdkrpwqrpb3hl6n5wi3woj
 ==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64-gcc-7.5.0-unzip-6.0-qos6nfhjj5mdkrpwqrpb3hl6n5wi3woj.spec.json.sig
 ==> Fetching file:///mirror/build_cache/linux-ubuntu18.04-x86_64/gcc-7.5.0/unzip-6.0/linux-ubuntu18.04-x86_64-gcc-7.5.0-unzip-6.0-qos6nfhjj5mdkrpwqrpb3hl6n5wi3woj.spack

--- a/outputs/cache/spack-mirror-all.out
+++ b/outputs/cache/spack-mirror-all.out
@@ -12,13 +12,13 @@ $ spack mirror create -d ~/mirror --all
 ==> Adding package berkeley-db@18.1.40 to mirror
 ==> Fetching https://mirror.spack.io/_source-cache/archive/0c/0cecb2ef0c67b166de93732769abdeba0555086d51de1090df325e18ee8da9c8.tar.gz
 ==> Adding package bzip2@1.0.8 to mirror
-==> Fetching https://mirror.spack.io/_source-cache/archive/ab/ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269.tar.gz
+==> Using cached archive: /home/spack/spack/var/spack/cache/_source-cache/archive/ab/ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269.tar.gz
 ==> Adding package cmake@3.23.1 to mirror
 ==> Fetching https://mirror.spack.io/_source-cache/archive/33/33fd10a8ec687a4d0d5b42473f10459bb92b3ae7def2b745dc10b192760869f3.tar.gz
 ==> Adding package curl@7.83.0 to mirror
 ==> Fetching https://mirror.spack.io/_source-cache/archive/24/247c7ec7521c4258e65634e529270d214fe32969971cccb72845e7aa46831f96.tar.bz2
 ==> Adding package diffutils@3.8 to mirror
-==> Fetching https://mirror.spack.io/_source-cache/archive/a6/a6bdd7d1b31266d11c4f4de6c1b748d4607ab0231af5188fc2533d0ae2438fec.tar.xz
+==> Using cached archive: /home/spack/spack/var/spack/cache/_source-cache/archive/a6/a6bdd7d1b31266d11c4f4de6c1b748d4607ab0231af5188fc2533d0ae2438fec.tar.xz
 ==> Adding package dtcmp@1.1.4 to mirror
 ==> Fetching https://mirror.spack.io/_source-cache/archive/dd/dd83d8cecd68e13b78b68e88675cc5847cde06742b7740e140b98f4a08127dd3.tar.gz
 ==> Adding package expat@2.4.8 to mirror
@@ -55,7 +55,7 @@ $ spack mirror create -d ~/mirror --all
 ==> Adding package libgpg-error@1.43 to mirror
 ==> Fetching https://mirror.spack.io/_source-cache/archive/a9/a9ab83ca7acc442a5bd846a75b920285ff79bdb4e3d34aa382be88ed2c3aebaf.tar.bz2
 ==> Adding package libiconv@1.16 to mirror
-==> Fetching https://mirror.spack.io/_source-cache/archive/e6/e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04.tar.gz
+==> Using cached archive: /home/spack/spack/var/spack/cache/_source-cache/archive/e6/e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04.tar.gz
 ==> Adding package libmd@1.0.4 to mirror
 ==> Fetching https://mirror.spack.io/_source-cache/archive/f5/f51c921042e34beddeded4b75557656559cf5b1f2448033b4c1eec11c07e530f.tar.xz
 ==> Adding package libpciaccess@0.16 to mirror
@@ -126,7 +126,7 @@ $ spack mirror create -d ~/mirror --all
 ==> Adding package py-wheel@0.37.0 to mirror
 ==> Fetching https://mirror.spack.io/_source-cache/archive/21/21014b2bd93c6d0034b6ba5d35e4eb284340e09d63c59aef6fc14b0f346146fd
 ==> Adding package python@3.9.12 to mirror
-==> Fetching https://www.python.org/ftp/python/3.9.12/Python-3.9.12.tgz
+==> Fetching https://mirror.spack.io/_source-cache/archive/70/70e08462ebf265012bd2be88a63d2149d880c73e53f1712b7bbbe93750560ae8.tgz
 ==> Adding package readline@8.1 to mirror
 ==> Fetching https://mirror.spack.io/_source-cache/archive/f8/f8ceb4ee131e3232226a17f51b164afc46cd0b9e6cef344be87c65962cb82b02.tar.gz
 ==> Adding package scr@2.0.0 to mirror
@@ -147,7 +147,7 @@ $ spack mirror create -d ~/mirror --all
 ==> Adding package xz@5.2.5 to mirror
 ==> Fetching https://mirror.spack.io/_source-cache/archive/51/5117f930900b341493827d63aa910ff5e011e0b994197c3b71c08a20228a42df.tar.bz2
 ==> Adding package zlib@1.2.12 to mirror
-==> Fetching https://mirror.spack.io/_source-cache/archive/91/91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9.tar.gz
+==> Using cached archive: /home/spack/spack/var/spack/cache/_source-cache/archive/91/91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9.tar.gz
 ==> Adding package zstd@1.5.2 to mirror
 ==> Fetching https://mirror.spack.io/_source-cache/archive/f7/f7de13462f7a82c29ab865820149e778cbfe01087b3a55b5332707abf9db4a6e.tar.gz
 ==> Successfully updated mirror in file:///home/spack/mirror


### PR DESCRIPTION
This tutorial section required almost no changes: the only meaningful changes are in `cache.sh`.

(oddly, although cache.sh had to be updated to checkout releases/v0.18, the `up-to-date.out` already shows output which reflects this - see https://github.com/spack/spack-tutorial/blob/main/outputs/cache/up-to-date.out)