### PR TITLE
wrong path to setup-env.sh?

### DIFF
--- a/tutorial_modules.rst
+++ b/tutorial_modules.rst
@@ -66,7 +66,7 @@ our module path.
 
 .. code-block:: console
 
-  $ . share/spack/setup-env.sh
+  $ . spack/share/spack/setup-env.sh
 
 .. FIXME: this needs bootstrap support for ``lmod``
 


### PR DESCRIPTION
Assuming you're in ~, there's no share folder there.