### PR TITLE
document compiler target field

### DIFF
--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -367,8 +367,18 @@ We can see that ``cppflags="-g"`` has been added to every node in the DAG.
 Advanced compiler configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-There are three fields of the compiler configuration entry that we
+There are four fields of the compiler configuration entry that we
 have not yet talked about.
+
+The ``target`` field of the compiler defines the cpu architecture **family**
+that the compiler supports.
+
+.. code-block:: yaml
+
+   - compiler:
+       ...
+       target: ppc64le
+       ...
 
 The ``modules`` field of the compiler is used primarily on Cray systems,
 but can be useful on any system that has compilers that are only


### PR DESCRIPTION
I found out the hard way that the `target` field only supports architecture families. Unless it's already documented somewhere and I couldn't find it, I'd like to add it.

```
==> Error: the "target" field in compilers.yaml accepts only target families [replace "x86_64_v3" with "x86_64" in "intel@2022.1.0" specification]
```