### PR TITLE
Fix the s3 bucket downloaded in the image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,9 +16,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 
 # Download the buildcache 
 RUN mkdir /mirror
-RUN aws --region us-east-1 --no-sign-request s3 sync s3://spack-binaries/releases/v0.19/tutorial /mirror
+RUN aws --region us-east-1 --no-sign-request s3 sync s3://spack-binaries/v0.19.0/tutorial /mirror
 RUN rm -rf /mirror/buid_cache/_pgp
-RUN aws --region us-east-1 --no-sign-request s3 sync s3://spack-binaries/releases/v0.19/build_cache/_pgp /mirror/build_cache/_pgp
+RUN aws --region us-east-1 --no-sign-request s3 sync s3://spack-binaries/v0.19.0/build_cache/_pgp /mirror/build_cache/_pgp
 
 FROM ubuntu:18.04 as builder
 


### PR DESCRIPTION
Using the bucket from a tag ensures we don't get duplicate builds