### PR TITLE
Update `_spack_root` submodule to v0.19.0

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/bash
-cd "${HOME}"
-rm -rf "${HOME}/spack"
-git clone https://github.com/spack/spack
-. spack/share/spack/setup-env.sh
-spack tutorial -y
-spack clean -m

--- a/docker/init.sh
+++ b/docker/init.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+cd "${HOME}"
+rm -rf "${HOME}/spack"
+git clone https://github.com/spack/spack
+. spack/share/spack/setup-env.sh
+spack tutorial -y
+spack clean -m

--- a/tutorial_buildsystems.rst
+++ b/tutorial_buildsystems.rst
@@ -111,9 +111,8 @@ This will open the :code:`AutotoolsPackage` file in your text editor.
 
 
 .. literalinclude:: _spack_root/lib/spack/spack/build_systems/autotools.py
-    :language: python
-    :emphasize-lines: 3,6,25-35
-    :lines: 80-101,404-426
+    :emphasize-lines: 2,4,22-31
+    :lines: 140-160,597-615
     :linenos:
 
 
@@ -211,8 +210,8 @@ Take note of the following:
 
 .. literalinclude:: _spack_root/lib/spack/spack/build_systems/makefile.py
    :language: python
-   :emphasize-lines: 57,63,70
-   :lines: 16-90
+   :emphasize-lines: 61,65,70
+   :lines: 35-109
    :linenos:
 
 Similar to :code:`Autotools`, :code:`MakefilePackage` class has properties
@@ -498,8 +497,8 @@ Let's look at these defaults in the :code:`CMakePackage` class in the :code:`_st
 
 .. literalinclude:: _spack_root/lib/spack/spack/build_systems/cmake.py
    :language: python
-   :lines: 33-71,123-191
-   :emphasize-lines: 61,71
+   :lines: 217-271
+   :emphasize-lines: 5,14
    :linenos:
 
 Some :code:`CMake` packages use different generators. Spack is able to support
@@ -698,7 +697,7 @@ We see the following:
 
 .. literalinclude:: _spack_root/lib/spack/spack/build_systems/python.py
    :language: python
-   :lines: 24-71
+   :lines: 176-204,273-290
    :linenos:
 
 Each of these methods have sensible defaults or they can be overridden.

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -443,7 +443,7 @@ file.
 
 .. literalinclude:: _spack_root/etc/spack/defaults/packages.yaml
    :language: yaml
-   :emphasize-lines: 18,41
+   :emphasize-lines: 18,45
 
 
 This sets the default preferences for compilers and for providers of

--- a/tutorial_modules.rst
+++ b/tutorial_modules.rst
@@ -946,7 +946,7 @@ are also permitted in the template language:
 
 .. literalinclude:: _spack_root/share/spack/templates/modules/modulefile.lua
   :language: jinja
-  :lines: 73-88
+  :lines: 73-87
 
 The locations where Spack looks for templates are specified
 in ``config.yaml``:


### PR DESCRIPTION
In a few parts of the tutorial we were still including literals from Spack v0.17.

Modifications:
- [x] Update submodule reference to Spack v0.19.0
- [x] Update a few scripts, defer to v0.19.1 for others