### PR TITLE
max height outputs

### DIFF
--- a/_static/css/custom.css
+++ b/_static/css/custom.css
@@ -1,0 +1,3 @@
+.rst-content div[class^="highlight"] pre {
+    max-height: 700px;
+}

--- a/conf.py
+++ b/conf.py
@@ -191,6 +191,11 @@ html_favicon = '_spack_root/share/spack/logo/favicon.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# These paths are either relative to html_static_path
+html_css_files = [
+    'css/custom.css',
+]
+
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 html_last_updated_fmt = '%b %d, %Y'


### PR DESCRIPTION
Avoid endless scrolling on the page by setting max height on outputs
