### PR TITLE
Modify graphiz to output diagrams as PNGs to emulate previous default

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,4 +26,4 @@ jobs:
     - name: Build docs
       run: |
         make clean --silent
-        make SPHINXOPTS=-W
+        make SPHINXOPTS="-W -D graphviz_output_format=png"


### PR DESCRIPTION
Building the documentation locally I'm unable to reproduce the error with the dot visualizations that are showing up in the online documentation. Sphinx's documentation mentions that graphviz now outputs to SVG instead of PNG by default so it may be worth reverting to PNG to see if that fixes the diagrams on the site.