### PR TITLE
mpirun: 2 ranks

### DIFF
--- a/outputs/environments.sh
+++ b/outputs/environments.sh
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
 }
 EOF
 example environments/use-mpi-1       'mpicc ./mpi-hello.c -I$(spack location -i zlib-ng)/include'
-example environments/use-mpi-1       "mpirun -n $(nproc) ./a.out"
+example environments/use-mpi-1       "mpirun -n 2 ./a.out"
 
 example environments/myproject-zlib-ng-1     "spack find zlib-ng"
 


### PR DESCRIPTION
Apparently it errors when > nproc, like in github actions, so fix to 2 instead
of 4

