### PR TITLE
Add artifact upload to allow us to test ci generated site

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,4 +26,8 @@ jobs:
     - name: Build docs
       run: |
         make clean --silent
-        make SPHINXOPTS="-W -D graphviz_output_format=png"
+        make SPHINXOPTS="-W"
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      with:
+        name: html
+        path: _build/html/


### PR DESCRIPTION
Add an artifact export to the site generation to allow us to see docs rendered by CI.