### PR TITLE
Add graphviz to the readthedocs build environment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,8 @@ build:
     # nodejs: "20"
     # rust: "1.70"
     # golang: "1.20"
+  apt_packages:
+    - graphviz
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
Adding `graphviz` as an apt package that is installed into the environment. Should fix issues with graphs not being displayed properly in the docs.