### PR TITLE
make spack.lock more readable by processing first with jq

### DIFF
--- a/outputs/environments.sh
+++ b/outputs/environments.sh
@@ -153,7 +153,7 @@ example environments/add-anonymous-1     "cat spack.yaml"
 example environments/remove-anonymous-1     "spack remove hdf5"
 example environments/remove-anonymous-1     "cat spack.yaml"
 
-example environments/lockfile-1          "head -30 <(jq < spack.lock)"
+example environments/lockfile-1          "jq < spack.lock | head -30"
 
 example environments/create-from-file-1  "spack env create abstract spack.yaml"
 

--- a/outputs/environments.sh
+++ b/outputs/environments.sh
@@ -153,7 +153,7 @@ example environments/add-anonymous-1     "cat spack.yaml"
 example environments/remove-anonymous-1     "spack remove hdf5"
 example environments/remove-anonymous-1     "cat spack.yaml"
 
-example environments/lockfile-1          "head -30 spack.lock"
+example environments/lockfile-1          "head -30 <(jq < spack.lock)"
 
 example environments/create-from-file-1  "spack env create abstract spack.yaml"
 

--- a/outputs/environments/lockfile-1.out
+++ b/outputs/environments/lockfile-1.out
@@ -1,1 +1,1 @@
-$ head -30 <(jq < spack.lock)
+$ jq < spack.lock | head -30

--- a/outputs/environments/lockfile-1.out
+++ b/outputs/environments/lockfile-1.out
@@ -1,1 +1,1 @@
-$ head -30 spack.lock
+$ head -30 <(jq < spack.lock)


### PR DESCRIPTION
Process spack.lock with `jq` before showing output snippet.