### PR TITLE
update setup.rst: clone ghcr.io/spack/tutorial:latest, not isc23 tag?

### DIFF
--- a/common/setup.rst
+++ b/common/setup.rst
@@ -2,7 +2,7 @@
 
    If you have not done the prior sections, you'll need to start the docker image::
 
-       docker run -it ghcr.io/spack/tutorial:isc23
+       docker run -it ghcr.io/spack/tutorial:latest
 
    and then set Spack up like this::
 


### PR DESCRIPTION
Should we be cloning the latest image here?