### PR TITLE
Update branches and tags for SC23

### DIFF
--- a/common/setup.rst
+++ b/common/setup.rst
@@ -2,7 +2,7 @@
 
    If you have not done the prior sections, you'll need to start the docker image::
 
-       docker run -it ghcr.io/spack/tutorial:isc23
+       docker run -it ghcr.io/spack/tutorial:sc23
 
    and then set Spack up like this::
 

--- a/index.rst
+++ b/index.rst
@@ -64,8 +64,8 @@ container image. You can invoke
 
 .. code-block:: console
 
-   $ docker pull ghcr.io/spack/tutorial:isc23
-   $ docker run -it ghcr.io/spack/tutorial:isc23
+   $ docker pull ghcr.io/spack/tutorial:sc23
+   $ docker run -it ghcr.io/spack/tutorial:sc23
 
 to start using the container. You should now be ready to run through our demo scripts:
 

--- a/outputs/defs.sh
+++ b/outputs/defs.sh
@@ -14,7 +14,7 @@ fi
 raw_outputs="${PROJECT}/raw"
 
 # used by scripts
-tutorial_branch=backports/v0.21.0
+tutorial_branch=releases/v0.21
 
 print_status() {
     printf "\n%b: %s\n\n" "\033[1;35m$1\033[0m" "$2"


### PR DESCRIPTION
This updates the branch in `defs.sh` to `releases/v0.21`. The tag of the docker image is updated to `sc23`. That tag should be generated automatically whenever the final version of the sc23 tutorial is tagged in this repository.