### PR TITLE
Update line numbers

### DIFF
--- a/tutorial/examples/Cmake/2.package.py
+++ b/tutorial/examples/Cmake/2.package.py
@@ -26,7 +26,7 @@ class Callpath(CMakePackage):
         args = ["-DCALLPATH_WALKER=dyninst"]
 
         if self.spec.satisfies("^dyninst@9.3.0:"):
-            std.flag = self.compiler.cxx_flag
+            std_flag = self.compiler.cxx_flag
             args.append("-DCMAKE_CXX_FLAGS='{0}' -fpermissive'".format(
                 std_flag))
 

--- a/tutorial_buildsystems.rst
+++ b/tutorial_buildsystems.rst
@@ -111,8 +111,8 @@ This will open the :code:`AutotoolsPackage` file in your text editor.
 
 
 .. literalinclude:: _spack_root/lib/spack/spack/build_systems/autotools.py
-    :emphasize-lines: 2,4,22-31
-    :lines: 140-160,597-615
+    :emphasize-lines: 2,4,12-21
+    :lines: 138-158,589-617
     :linenos:
 
 
@@ -210,8 +210,8 @@ Take note of the following:
 
 .. literalinclude:: _spack_root/lib/spack/spack/build_systems/makefile.py
    :language: python
-   :emphasize-lines: 61,65,70
-   :lines: 35-109
+   :emphasize-lines: 60,64,69
+   :lines: 40-111
    :linenos:
 
 Similar to :code:`Autotools`, :code:`MakefilePackage` class has properties
@@ -497,8 +497,8 @@ Let's look at these defaults in the :code:`CMakePackage` class in the :code:`_st
 
 .. literalinclude:: _spack_root/lib/spack/spack/build_systems/cmake.py
    :language: python
-   :lines: 217-271
-   :emphasize-lines: 5,14
+   :lines: 167-300
+   :emphasize-lines: 87,96
    :linenos:
 
 Some :code:`CMake` packages use different generators. Spack is able to support
@@ -639,68 +639,18 @@ so we override the :code:`install()` method to do it for us:
 PythonPackage
 --------------
 
-Python extensions and modules are built differently from source than most
-applications. Python uses a :code:`setup.py` script to install Python modules.
-The script consists of a call to :code:`setup()` which provides the information
-required to build a module to Distutils. If you're familiar with pip or
-easy_install, setup.py does the same thing.
-
+Python extensions and modules are built differently from source than most applications.
 These modules are usually installed using the following line:
 
 .. code-block:: console
 
-    $ python setup.py install
-
-There are also a list of commands and phases that you can call. To see the full
-list you can run:
-
-.. code-block:: console
-
-    $ python setup.py --help-commands
-    Standard commands:
-        build             build everything needed to install
-        build_py          "build" pure Python modules (copy to build directory)
-        build_ext         build C/C++ extensions (compile/link to build directory)
-        build_clib        build C/C++ libraries used by Python extensions
-        build_scripts     "build" scripts (copy and fixup #! line)
-        clean             (no description available)
-        install           install everything from build directory
-        install_lib       install all Python modules (extensions and pure Python)
-        install_headers   install C/C++ header files
-        install_scripts   install scripts (Python or otherwise)
-        install_data      install data files
-        sdist             create a source distribution (tarball, zip file, etc.)
-        register          register the distribution with the Python package index
-        bdist             create a built (binary) distribution
-        bdist_dumb        create a "dumb" built distribution
-        bdist_rpm         create an RPM distribution
-        bdist_wininst     create an executable installer for MS Windows
-        upload            upload binary package to PyPI
-        check             perform some checks on the package
+    $ pip install .
 
 
 We can write package files for Python packages using the :code:`Package` class,
 but the class brings with it a lot of methods that are useless for Python packages.
 Instead, Spack has a :code:`PythonPackage` subclass that allows packagers
-of Python modules to be able to invoke :code:`setup.py` and use :code:`Distutils`,
-which is much more familiar to a typical python user.
-
-To see the defaults that Spack has for each a methods, we will take a look
-at the :code:`PythonPackage` class:
-
-.. code-block:: console
-
-    $ spack edit --build-system python
-
-We see the following:
-
-
-.. literalinclude:: _spack_root/lib/spack/spack/build_systems/python.py
-   :language: python
-   :lines: 176-204,273-290
-   :linenos:
-
-Each of these methods have sensible defaults or they can be overridden.
+of Python modules to be able to invoke :code:`pip`.
 
 We will write a package file for Pandas_:
 

--- a/tutorial_buildsystems.rst
+++ b/tutorial_buildsystems.rst
@@ -111,7 +111,7 @@ This will open the :code:`AutotoolsPackage` file in your text editor.
 
 
 .. literalinclude:: _spack_root/lib/spack/spack/build_systems/autotools.py
-    :emphasize-lines: 2,4,12-21
+    :emphasize-lines: 2,4,28-37
     :lines: 138-158,589-617
     :linenos:
 

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -464,7 +464,7 @@ MPICH over OpenMPI. Currently, we prefer GCC and OpenMPI.
 
 .. literalinclude:: outputs/config/0.prefs.out
    :language: console
-   :emphasize-lines: 21
+   :emphasize-lines: 16
 
 
 Let's override these default preferences in an environment. When you
@@ -506,7 +506,7 @@ overrides the default settings just for these two items.
 
 .. literalinclude:: outputs/config/1.prefs.out
    :language: console
-   :emphasize-lines: 21
+   :emphasize-lines: 18
 
 
 ^^^^^^^^^^^^^^^^^^^
@@ -674,10 +674,10 @@ Notice that we still haven't build ``hdf5`` with our external
 
       1. hdf5: '+mpi' conflicts with '^mpich@4.0:4.0.3'
       2. hdf5: '+mpi' conflicts with '^mpich@4.0:4.0.3'
-           required because conflict applies to spec ^mpich@4.0:4.0.3 
-             required because hdf5%clang+mpi requested from CLI 
-           required because conflict is triggered when +mpi 
-             required because hdf5%clang+mpi requested from CLI 
+           required because conflict applies to spec ^mpich@4.0:4.0.3
+             required because hdf5%clang+mpi requested from CLI
+           required because conflict is triggered when +mpi
+             required because hdf5%clang+mpi requested from CLI
 
 In this case, we cannot use the external mpich. The version is
 incompatible with ``hdf5``. At this point, the best option is to give

--- a/tutorial_modules.rst
+++ b/tutorial_modules.rst
@@ -48,7 +48,7 @@ and by enabling ``tcl`` module files, which are disabled by default since Spack 
 
   $ spack config add "modules:default:enable:[tcl]"
 
-  
+
 ^^^^^^^^^^^^^^^^^^^
 Build a module tool
 ^^^^^^^^^^^^^^^^^^^
@@ -308,7 +308,7 @@ This can be done either editing the configuration manually, or directly from the
 .. code-block:: console
 
    $ spack config add "modules:default:tcl:all:filter:exclude_env_vars:['CC', 'CXX', 'F77', 'FC']"
-	      
+
 Next you should regenerate all the module files:
 
 .. literalinclude:: outputs/modules/tcl-refresh-1.out
@@ -482,7 +482,6 @@ the names are formatted to differentiate them:
             - "CXX"
             - "FC"
             - "F77"
-
         projections:
           all:               '{name}/{version}-{compiler.name}-{compiler.version}'
           netlib-scalapack:  '{name}/{version}-{compiler.name}-{compiler.version}-{^lapack.name}-{^mpi.name}'
@@ -615,7 +614,7 @@ This time we will be more selective and regenerate only the ``openmpi`` module f
 
 
 .. FIXME: remove this?
-	      
+
 ^^^^^^^^^^^^^^^^^^^^^
 Autoload dependencies
 ^^^^^^^^^^^^^^^^^^^^^

--- a/tutorial_packaging.rst
+++ b/tutorial_packaging.rst
@@ -321,7 +321,7 @@ failed installation:
 
 .. literalinclude:: outputs/packaging/build-output.out
    :language: console
-   :emphasize-lines: 1,33
+   :emphasize-lines: 1,35
 
 In this case the error conveniently appears on the last line of the
 log *and* the output from `spack install`.
@@ -449,7 +449,7 @@ Now let's try the build again:
 
 .. literalinclude:: outputs/packaging/install-mpileaks-3.out
    :language: console
-   :emphasize-lines: 1,30-31
+   :emphasize-lines: 1,31-32
 
 Success!
 
@@ -727,7 +727,6 @@ Undo the work we've done here by entering the following commands:
 
 .. literalinclude:: outputs/packaging/cleanup.out
    :language: console
-   :emphasize-lines: 1,3,5
 
 --------------------
 More information

--- a/tutorial_spack_scripting.rst
+++ b/tutorial_spack_scripting.rst
@@ -37,7 +37,7 @@ using the following commands:
 
 .. literalinclude:: outputs/scripting/setup.out
    :language: console
-   :emphasize-lines: 1,27,29,282
+   :emphasize-lines: 1,31,33,321
 
 Now we are ready to use the Spack's ``find`` and ``python`` subcommands
 to query the installed packages.


### PR DESCRIPTION
Build Systems Tutorial needs a complete overhaul since we overhauled multi-build system support and changed how Python packages are installed. But we aren't giving that tutorial today so this can wait.