### PR TITLE
ci: rebuild container on merge to main

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -3,6 +3,10 @@ name: Containers
 on:
   workflow_dispatch:
 
+  push:
+    branches:
+      - main
+
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Because who has time to wait for the nightly job to pick up the new changes.