### PR TITLE
scripting: add globals for store.STORE

### DIFF
--- a/outputs/scripting/0.find_exclude.py.example
+++ b/outputs/scripting/0.find_exclude.py.example
@@ -6,7 +6,7 @@ import sys
 include_spec = Spec(sys.argv[1])
 exclude_spec = Spec(sys.argv[2])
 
-all_included = spack.store.db.query(include_spec)
+all_included = spack.store.STORE.db.query(include_spec)
 result = filter(lambda spec: not spec.satisfies(exclude_spec), all_included)
 
 spack.cmd.display_specs(result)

--- a/outputs/scripting/1.find_exclude.py.example
+++ b/outputs/scripting/1.find_exclude.py.example
@@ -7,7 +7,7 @@ import sys
 include_spec = Spec(sys.argv[1])
 exclude_spec = Spec(sys.argv[2])
 
-all_included = spack.store.db.query(include_spec)
+all_included = spack.store.STORE.db.query(include_spec)
 result = filter(lambda spec: not spec.satisfies(exclude_spec), all_included)
 
 spack.cmd.display_specs(result)

--- a/outputs/scripting/2.find_exclude.py.example
+++ b/outputs/scripting/2.find_exclude.py.example
@@ -7,7 +7,7 @@ import sys
 include_spec = Spec(sys.argv[1])
 exclude_spec = Spec(sys.argv[2])
 
-all_included = spack.store.db.query(include_spec)
+all_included = spack.store.STORE.db.query(include_spec)
 result = filter(lambda spec: not spec.satisfies(exclude_spec), all_included)
 
 spack.cmd.display_specs(result)

--- a/outputs/scripting/spack-python-db-query-exclude.out
+++ b/outputs/scripting/spack-python-db-query-exclude.out
@@ -1,5 +1,5 @@
   >>> gcc_query_spec = Spec('%gcc')
-  >>> gcc_specs = spack.store.db.query(gcc_query_spec)
+  >>> gcc_specs = spack.store.STORE.db.query(gcc_query_spec)
   >>> result = filter(lambda spec: not spec.satisfies('^mpich'), gcc_specs)
   >>> import spack.cmd
   >>> spack.cmd.display_specs(result)


### PR DESCRIPTION
We'd forgotten to update the tutorial examples when we moved to `spack.store.STORE`. Fixing that here.