### PR TITLE
update scripting section

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -93,7 +93,7 @@ Full contents:
    tutorial_stacks
    tutorial_developer_workflows
    tutorial_binary_cache
-   tutorial_spack_scripting
+   tutorial_scripting
 
 .. toctree::
    :maxdepth: 3

--- a/outputs/scripting/1.find_exclude.py.example
+++ b/outputs/scripting/1.find_exclude.py.example
@@ -1,4 +1,4 @@
-#!/usr/bin/env spack-python
+#!/usr/bin/env spack python
 from spack.spec import Spec
 import spack.store
 import spack.cmd

--- a/tutorial_scripting.rst
+++ b/tutorial_scripting.rst
@@ -24,24 +24,6 @@ Since Spack has an extensive API, we'll only scratch the surface here.
 We'll give you enough information to start writing your own scripts and
 to find what you need, with a little digging.
 
------------------------
-Setting up the tutorial
------------------------
-
-Before proceeding, let's ensure the outputs for this segment are reasonable.
-Since you may have a lot of packages installed from earlier sections of the
-tutorial, we want to perform a little cleanup.
-
-Let's remove ``gcc@8.3.0`` and re-install ``hdf5`` and ``zlib@clang``
-using the following commands:
-
-.. literalinclude:: outputs/scripting/setup.out
-   :language: console
-   :emphasize-lines: 1,31,33,321
-
-Now we are ready to use the Spack's ``find`` and ``python`` subcommands
-to query the installed packages.
-
 -----------------------------
 Scripting with ``spack find``
 -----------------------------


### PR DESCRIPTION
1. Remove distracting setup section that wastes time
2. Fix typo in find/exclude example
3. Rename .rst file to match the rest of the tutorial

NOTE: Do not merge without checking outputs. The output generation messes with the example text and I want to double-check that it's not the source of the find/exclude typo before merging.