### PR TITLE
Fix broken link to old packaging guide page

### DIFF
--- a/tutorial_packaging.rst
+++ b/tutorial_packaging.rst
@@ -635,7 +635,7 @@ More information
 --------------------
 
 This tutorial module only scratches the surface of defining Spack package recipes.
-The `Packaging Guide <https://spack.readthedocs.io/en/latest/packaging_guide.html#>`_ covers packaging topics more thoroughly.
+The `Packaging Guide <https://spack.readthedocs.io/en/latest/packaging_guide_creation.html#>`_ covers packaging topics more thoroughly.
 
 Additional information on key topics can be found at the links below.
 


### PR DESCRIPTION
Link is broken after https://github.com/spack/spack/pull/50884 split the packaging guide into separate sections. Replace with a link to the new first section page of the packaging guide.