### PR TITLE
basics: move graph example to tcl (from hdf5) demo `spack spec hdf5`

### DIFF
--- a/outputs/basics.sh
+++ b/outputs/basics.sh
@@ -51,14 +51,15 @@ example basics/tcl-zlib-hash  "spack install tcl ^/${zlib_hash}"
 
 example basics/find-ldf        "spack find -ldf"
 
+example basics/graph-tcl       "spack graph tcl"
+
+example basics/hdf5-spec       "spack spec hdf5"
 example basics/hdf5            "spack install hdf5"
 example basics/hdf5-no-mpi     "spack install hdf5~mpi"
 
 example basics/hdf5-hl-mpi     "spack install hdf5+hl+mpi ^mpich"
 
 example basics/find-ldf-2      "spack find -ldf"
-
-example basics/graph-hdf5      "spack graph hdf5+hl+mpi ^mpich"
 
 example basics/trilinos        "spack install trilinos"
 

--- a/tutorial_basics.rst
+++ b/tutorial_basics.rst
@@ -166,9 +166,23 @@ Note that each package has a top-level entry, even if it also appears as a depen
 .. literalinclude:: outputs/basics/find-ldf.out
    :language: console
 
+Spack models the dependencies of packages as a directed acyclic graph (DAG).
+The ``spack find -d`` command shows the tree representation of that graph, which loses some dependency relationship information.
+We can also use the ``spack graph`` command to view the entire DAG as a graph.
+
+.. literalinclude:: outputs/basics/graph-tcl.out
+   :language: console
+
 Let's move on to slightly more complicated packages.
 HDF5 is a good example of a more complicated package, with an MPI dependency.
 If we install it with default settings it will build with OpenMPI.
+We can check the install plan in advance to ensure it's what we want to install using the ``spack spec`` command.
+The ``spack spec`` command accepts the same spec syntax.
+
+.. literalinclude:: outputs/basics/hdf5-spec.out
+   :language: console
+
+Assuming we're happy with that configuration, we will now install it.
 
 .. literalinclude:: outputs/basics/hdf5.out
    :language: console
@@ -199,13 +213,6 @@ The partial spec ``^mpi@3`` can be satisfied by any of several MPI implementatio
 We'll do a quick check in on what we have installed so far.
 
 .. literalinclude:: outputs/basics/find-ldf-2.out
-   :language: console
-
-Spack models the dependencies of packages as a directed acyclic graph (DAG).
-The ``spack find -d`` command shows the tree representation of that graph.
-We can also use the ``spack graph`` command to view the entire DAG as a graph.
-
-.. literalinclude:: outputs/basics/graph-hdf5.out
    :language: console
 
 HDF5 is more complicated than our basic example of zlib-ng and Tcl, but it's still within the realm of software that an experienced HPC user could reasonably expect to manually install given a bit of time.


### PR DESCRIPTION
The `spack graph` command demo on hdf5 was designed to be on something simple enough that the ASCII graph was sufficient. That's not true for hdf5 anymore, so we switch to doing it for tcl.

Also add an example using `spack spec` as part of the hdf5 demos.