### PR TITLE
Update config tutorial section to 1.0

### DIFF
--- a/outputs/config/0.compiler_flags.out
+++ b/outputs/config/0.compiler_flags.out
@@ -1,24 +1,7 @@
-$ spack spec json-fortran%clang@14.0.0-gfortran
-Input spec
---------------------------------
- -   json-fortran%clang@14.0.0-gfortran
-
-Concretized
---------------------------------
- -   json-fortran@8.3.0%clang@14.0.0-gfortran cppflags="-g" ~ipo build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64_v3
- -       ^cmake@3.27.7%clang@14.0.0-gfortran cppflags="-g" ~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-ubuntu22.04-x86_64_v3
- -           ^curl@8.4.0%clang@14.0.0-gfortran cppflags="-g" ~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-ubuntu22.04-x86_64_v3
- -               ^nghttp2@1.57.0%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -               ^openssl@3.1.3%clang@14.0.0-gfortran cppflags="-g" ~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu22.04-x86_64_v3
- -                   ^ca-certificates-mozilla@2023-05-30%clang@14.0.0-gfortran cppflags="-g"  build_system=generic arch=linux-ubuntu22.04-x86_64_v3
- -                   ^perl@5.38.0%clang@14.0.0-gfortran cppflags="-g" +cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-ubuntu22.04-x86_64_v3
- -                       ^berkeley-db@18.1.40%clang@14.0.0-gfortran cppflags="-g" +cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-ubuntu22.04-x86_64_v3
- -                       ^bzip2@1.0.8%clang@14.0.0-gfortran cppflags="-g" ~debug~pic+shared build_system=generic arch=linux-ubuntu22.04-x86_64_v3
- -                           ^diffutils@3.9%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                               ^libiconv@1.17%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools libs=shared,static arch=linux-ubuntu22.04-x86_64_v3
- -                       ^gdbm@1.23%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                           ^readline@8.2%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools patches=bbf97f1 arch=linux-ubuntu22.04-x86_64_v3
- -               ^pkgconf@1.9.5%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -           ^ncurses@6.4%clang@14.0.0-gfortran cppflags="-g" ~symlinks+termlib abi=none build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -           ^zlib-ng@2.1.4%clang@14.0.0-gfortran cppflags="-g" +compat+opt build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -       ^gmake@4.4.1%clang@14.0.0-gfortran cppflags="-g" ~guile build_system=generic arch=linux-ubuntu22.04-x86_64_v3
+$ spack spec zlib%gcc@11.4.0
+ -   zlib@1.3.1 cppflags=-g +optimize+pic+shared build_system=makefile arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -       ^compiler-wrapper@1.0 build_system=generic arch=linux-ubuntu22.04-x86_64
+[e]      ^gcc@11.4.0~binutils+bootstrap~graphite~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' arch=linux-ubuntu22.04-x86_64
+ -       ^gcc-runtime@11.4.0 cppflags=-g  build_system=generic arch=linux-ubuntu22.04-x86_64
+[e]      ^glibc@2.35 build_system=autotools arch=linux-ubuntu22.04-x86_64
+ -       ^gmake@4.4.1 cppflags=-g ~guile build_system=generic arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0

--- a/outputs/config/0.prefs.out
+++ b/outputs/config/0.prefs.out
@@ -1,48 +1,48 @@
 $ spack spec hdf5
-Input spec
---------------------------------
- -   hdf5
-
-Concretized
---------------------------------
-[+]  hdf5@1.14.3%gcc@11.4.0~cxx~fortran~hl~ipo~java~map+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64_v3
-[+]      ^cmake@3.27.7%gcc@11.4.0~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-ubuntu22.04-x86_64_v3
-[+]          ^curl@8.4.0%gcc@11.4.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^nghttp2@1.57.0%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^openssl@3.1.3%gcc@11.4.0~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu22.04-x86_64_v3
-[+]                  ^ca-certificates-mozilla@2023-05-30%gcc@11.4.0 build_system=generic arch=linux-ubuntu22.04-x86_64_v3
-[+]          ^ncurses@6.4%gcc@11.4.0~symlinks+termlib abi=none build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]      ^gmake@4.4.1%gcc@11.4.0~guile build_system=generic arch=linux-ubuntu22.04-x86_64_v3
-[+]      ^openmpi@4.1.6%gcc@11.4.0~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~internal-pmix~java~legacylaunchers~lustre~memchecker~openshmem~orterunprefix+romio+rsh~singularity+static+vt+wrapper-rpath build_system=autotools fabrics=none schedulers=none arch=linux-ubuntu22.04-x86_64_v3
-[+]          ^hwloc@2.9.1%gcc@11.4.0~cairo~cuda~gl~libudev+libxml2~netloc~nvml~oneapi-level-zero~opencl+pci~rocm build_system=autotools libs=shared,static arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^libpciaccess@0.17%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]                  ^util-macros@1.19.3%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^libxml2@2.10.3%gcc@11.4.0+pic~python+shared build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]                  ^libiconv@1.17%gcc@11.4.0 build_system=autotools libs=shared,static arch=linux-ubuntu22.04-x86_64_v3
-[+]                  ^xz@5.4.1%gcc@11.4.0~pic build_system=autotools libs=shared,static arch=linux-ubuntu22.04-x86_64_v3
-[+]          ^numactl@2.0.14%gcc@11.4.0 build_system=autotools patches=4e1d78c,62fc8a8,ff37630 arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^autoconf@2.69%gcc@11.4.0 build_system=autotools patches=35c4492,7793209,a49dd5b arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^automake@1.16.5%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^libtool@2.4.7%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^m4@1.4.19%gcc@11.4.0+sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-ubuntu22.04-x86_64_v3
-[+]                  ^diffutils@3.9%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]                  ^libsigsegv@2.14%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]          ^openssh@9.5p1%gcc@11.4.0+gssapi build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^krb5@1.20.1%gcc@11.4.0+shared build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]                  ^bison@3.8.2%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]                  ^findutils@4.9.0%gcc@11.4.0 build_system=autotools patches=440b954 arch=linux-ubuntu22.04-x86_64_v3
-[+]                  ^gettext@0.22.3%gcc@11.4.0+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]                      ^tar@1.34%gcc@11.4.0 build_system=autotools zip=pigz arch=linux-ubuntu22.04-x86_64_v3
-[+]                          ^pigz@2.7%gcc@11.4.0 build_system=makefile arch=linux-ubuntu22.04-x86_64_v3
-[+]                          ^zstd@1.5.5%gcc@11.4.0+programs build_system=makefile compression=none libs=shared,static arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^libedit@3.1-20210216%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^libxcrypt@4.4.35%gcc@11.4.0~obsolete_api build_system=autotools patches=4885da3 arch=linux-ubuntu22.04-x86_64_v3
-[+]          ^perl@5.38.0%gcc@11.4.0+cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^berkeley-db@18.1.40%gcc@11.4.0+cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^bzip2@1.0.8%gcc@11.4.0~debug~pic+shared build_system=generic arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^gdbm@1.23%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]                  ^readline@8.2%gcc@11.4.0 build_system=autotools patches=bbf97f1 arch=linux-ubuntu22.04-x86_64_v3
-[+]          ^pmix@5.0.1%gcc@11.4.0~docs+pmi_backwards_compatibility~python~restful build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]              ^libevent@2.1.12%gcc@11.4.0+openssl build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]      ^pkgconf@1.9.5%gcc@11.4.0 build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
-[+]      ^zlib-ng@2.1.4%gcc@11.4.0+compat+opt build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
+ -   hdf5@1.14.6~cxx~fortran~hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -       ^cmake@3.31.8~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -           ^curl@8.11.1~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -               ^nghttp2@1.65.0 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -                   ^diffutils@3.10 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -               ^openssl@3.4.1~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -                   ^ca-certificates-mozilla@2025-05-20 build_system=generic arch=linux-ubuntu22.04-x86_64 
+ -           ^ncurses@6.5-20250705~symlinks+termlib abi=none build_system=autotools patches:=7a351bc arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -       ^compiler-wrapper@1.0 build_system=generic arch=linux-ubuntu22.04-x86_64 
+[e]      ^gcc@11.4.0~binutils+bootstrap~graphite~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' arch=linux-ubuntu22.04-x86_64 
+ -       ^gcc-runtime@11.4.0 build_system=generic arch=linux-ubuntu22.04-x86_64 
+[e]      ^glibc@2.35 build_system=autotools arch=linux-ubuntu22.04-x86_64 
+ -       ^gmake@4.4.1~guile build_system=generic arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -       ^openmpi@5.0.8+atomics~cuda~debug+fortran~gpfs~internal-hwloc~internal-libevent~internal-pmix~ipv6~java~lustre~memchecker~openshmem~rocm~romio+rsh~static~two_level_namespace+vt+wrapper-rpath build_system=autotools fabrics:=none romio-filesystem:=none schedulers:=none arch=linux-ubuntu22.04-x86_64 %c,cxx,fortran=gcc@11.4.0
+ -           ^autoconf@2.72 build_system=autotools arch=linux-ubuntu22.04-x86_64 
+ -               ^m4@1.4.20+sigsegv build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -                   ^libsigsegv@2.14 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -           ^automake@1.16.5 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -           ^hwloc@2.11.1~cairo~cuda~gl~level_zero~libudev+libxml2~nvml~opencl+pci~rocm build_system=autotools libs:=shared,static arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -               ^libpciaccess@0.17 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -                   ^util-macros@1.20.1 build_system=autotools arch=linux-ubuntu22.04-x86_64 
+ -               ^libxml2@2.13.5~http+pic~python+shared build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -                   ^libiconv@1.18 build_system=autotools libs:=shared,static arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -                   ^xz@5.6.3~pic build_system=autotools libs:=shared,static arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -           ^libevent@2.1.12+openssl build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -           ^libtool@2.4.7 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -               ^findutils@4.10.0 build_system=autotools patches:=440b954 arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -                   ^gettext@0.23.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -                       ^tar@1.35 build_system=autotools zip=pigz arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -                           ^pigz@2.8 build_system=makefile arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -                           ^zstd@1.5.7+programs build_system=makefile compression:=none libs:=shared,static arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -           ^numactl@2.0.18 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -           ^openssh@9.9p1+gssapi build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -               ^krb5@1.21.3+shared build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -                   ^bison@3.8.2~color build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -               ^libedit@3.1-20240808 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -               ^libxcrypt@4.4.38~obsolete_api build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -           ^perl@5.42.0+cpanm+opcode+open+shared+threads build_system=generic arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -               ^berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -               ^bzip2@1.0.8~debug~pic+shared build_system=generic arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -               ^gdbm@1.23 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -                   ^readline@8.3 build_system=autotools patches:=21f0a03 arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -           ^pmix@6.0.0~munge~python build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -           ^prrte@4.0.0 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -               ^flex@2.6.3+lex~nls build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0
+ -       ^pkgconf@2.5.1 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -       ^zlib-ng@2.2.4+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=gcc@11.4.0

--- a/outputs/config/1.prefs.out
+++ b/outputs/config/1.prefs.out
@@ -1,50 +1,48 @@
 $ spack spec hdf5
-Input spec
---------------------------------
- -   hdf5
-
-Concretized
---------------------------------
- -   hdf5@1.14.3%clang@14.0.0-gfortran cppflags="-g" ~cxx~fortran~hl~ipo~java~map+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64_v3
- -       ^cmake@3.27.7%clang@14.0.0-gfortran cppflags="-g" ~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-ubuntu22.04-x86_64_v3
- -           ^curl@8.4.0%clang@14.0.0-gfortran cppflags="-g" ~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-ubuntu22.04-x86_64_v3
- -               ^nghttp2@1.57.0%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -               ^openssl@3.1.3%clang@14.0.0-gfortran cppflags="-g" ~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu22.04-x86_64_v3
- -                   ^ca-certificates-mozilla@2023-05-30%clang@14.0.0-gfortran cppflags="-g"  build_system=generic arch=linux-ubuntu22.04-x86_64_v3
- -                   ^perl@5.38.0%clang@14.0.0-gfortran cppflags="-g" +cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-ubuntu22.04-x86_64_v3
- -                       ^berkeley-db@18.1.40%clang@14.0.0-gfortran cppflags="-g" +cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-ubuntu22.04-x86_64_v3
- -           ^ncurses@6.4%clang@14.0.0-gfortran cppflags="-g" ~symlinks+termlib abi=none build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -       ^gmake@4.4.1%clang@14.0.0-gfortran cppflags="-g" ~guile build_system=generic arch=linux-ubuntu22.04-x86_64_v3
- -       ^mpich@4.1.2%clang@14.0.0-gfortran cppflags="-g" ~argobots~cuda+fortran+hwloc+hydra+libxml2+pci~rocm+romio~slurm~vci~verbs+wrapperrpath build_system=autotools datatype-engine=auto device=ch4 netmod=ofi pmi=pmi arch=linux-ubuntu22.04-x86_64_v3
- -           ^findutils@4.9.0%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools patches=440b954 arch=linux-ubuntu22.04-x86_64_v3
- -           ^hwloc@2.9.1%clang@14.0.0-gfortran cppflags="-g" ~cairo~cuda~gl~libudev+libxml2~netloc~nvml~oneapi-level-zero~opencl+pci~rocm build_system=autotools libs=shared,static arch=linux-ubuntu22.04-x86_64_v3
- -           ^libfabric@1.19.0%clang@14.0.0-gfortran cppflags="-g" ~debug~kdreg build_system=autotools fabrics=sockets,tcp,udp arch=linux-ubuntu22.04-x86_64_v3
- -           ^libpciaccess@0.17%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -               ^libtool@2.4.7%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -               ^util-macros@1.19.3%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -           ^libxml2@2.10.3%clang@14.0.0-gfortran cppflags="-g" +pic~python+shared build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -               ^libiconv@1.17%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools libs=shared,static arch=linux-ubuntu22.04-x86_64_v3
- -               ^xz@5.4.1%clang@14.0.0-gfortran cppflags="-g" ~pic build_system=autotools libs=shared,static arch=linux-ubuntu22.04-x86_64_v3
- -           ^yaksa@0.3%clang@14.0.0-gfortran cppflags="-g" ~cuda~rocm build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -               ^autoconf@2.69%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools patches=35c4492,7793209,a49dd5b arch=linux-ubuntu22.04-x86_64_v3
- -               ^automake@1.16.5%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -               ^m4@1.4.19%clang@14.0.0-gfortran cppflags="-g" +sigsegv build_system=autotools patches=9dc5fbd,bfdffa7 arch=linux-ubuntu22.04-x86_64_v3
- -                   ^diffutils@3.9%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                   ^libsigsegv@2.14%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -               ^python@3.11.6%clang@14.0.0-gfortran cppflags="-g" +bz2+crypt+ctypes+dbm~debug+libxml2+lzma~nis~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic patches=13fa8bf,b0615b2,ebdca64,f2fd060 arch=linux-ubuntu22.04-x86_64_v3
- -                   ^bzip2@1.0.8%clang@14.0.0-gfortran cppflags="-g" ~debug~pic+shared build_system=generic arch=linux-ubuntu22.04-x86_64_v3
- -                   ^expat@2.5.0%clang@14.0.0-gfortran cppflags="-g" +libbsd build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                       ^libbsd@0.11.7%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                           ^libmd@1.0.4%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                   ^gdbm@1.23%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                   ^gettext@0.22.3%clang@14.0.0-gfortran cppflags="-g" +bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                       ^tar@1.34%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools zip=pigz arch=linux-ubuntu22.04-x86_64_v3
- -                           ^pigz@2.7%clang@14.0.0-gfortran cppflags="-g"  build_system=makefile arch=linux-ubuntu22.04-x86_64_v3
- -                           ^zstd@1.5.5%clang@14.0.0-gfortran cppflags="-g" +programs build_system=makefile compression=none libs=shared,static arch=linux-ubuntu22.04-x86_64_v3
- -                   ^libffi@3.4.4%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                   ^libxcrypt@4.4.35%clang@14.0.0-gfortran cppflags="-g" ~obsolete_api build_system=autotools patches=4885da3 arch=linux-ubuntu22.04-x86_64_v3
- -                   ^readline@8.2%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools patches=bbf97f1 arch=linux-ubuntu22.04-x86_64_v3
- -                   ^sqlite@3.43.2%clang@14.0.0-gfortran cppflags="-g" +column_metadata+dynamic_extensions+fts~functions+rtree build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                   ^util-linux-uuid@2.38.1%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -       ^pkgconf@1.9.5%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -       ^zlib-ng@2.1.4%clang@14.0.0-gfortran cppflags="-g" +compat+opt build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
+ -   hdf5@1.14.6~cxx~fortran~hl~ipo~java~map+mpi+shared~subfiling~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -       ^cmake@3.31.8~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -           ^curl@8.11.1~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -               ^nghttp2@1.65.0 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -                   ^diffutils@3.10 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -               ^openssl@3.4.1~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -                   ^ca-certificates-mozilla@2025-05-20 build_system=generic arch=linux-ubuntu22.04-x86_64 
+ -                   ^perl@5.42.0+cpanm+opcode+open+shared+threads build_system=generic arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                       ^berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -           ^ncurses@6.5-20250705~symlinks+termlib abi=none build_system=autotools patches:=7a351bc arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -       ^compiler-wrapper@1.0 build_system=generic arch=linux-ubuntu22.04-x86_64 
+[e]      ^glibc@2.35 build_system=autotools arch=linux-ubuntu22.04-x86_64 
+ -       ^gmake@4.4.1~guile build_system=generic arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+[e]      ^llvm@14.0.0+clang~cuda~flang+gold+libomptarget~libomptarget_debug~link_llvm_dylib~lld~lldb+llvm_dylib+lua~mlir+polly~python~split_dwarf~z3 build_system=cmake build_type=Release compiler-rt=runtime generator=ninja libcxx=runtime libunwind=runtime openmp=runtime patches:=1f42874,25bc503,6379168,8248141,b216cff,cb8e645 shlib_symbol_version=none targets:=all version_suffix=none arch=linux-ubuntu22.04-x86_64 
+ -       ^mpich@4.3.1~argobots~cuda+fortran+hwloc+hydra~level_zero+libxml2+pci~rocm+romio~slurm~vci~verbs+wrapperrpath~xpmem build_system=autotools datatype-engine=auto device=ch4 netmod=ofi pmi=default arch=linux-ubuntu22.04-x86_64 %fortran=gcc@11.4.0 %c,cxx=clang@14.0.0
+ -           ^findutils@4.10.0 build_system=autotools patches:=440b954 arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -               ^gettext@0.23.1+bzip2+curses+git~libunistring+libxml2+pic+shared+tar+xz build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -                   ^bzip2@1.0.8~debug~pic+shared build_system=generic arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                   ^tar@1.35 build_system=autotools zip=pigz arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                       ^pigz@2.8 build_system=makefile arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                       ^zstd@1.5.7+programs build_system=makefile compression:=none libs:=shared,static arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+[e]          ^gcc@11.4.0~binutils+bootstrap~graphite~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' arch=linux-ubuntu22.04-x86_64 
+ -           ^gcc-runtime@11.4.0 build_system=generic arch=linux-ubuntu22.04-x86_64 
+ -           ^hwloc@2.11.1~cairo~cuda~gl~level_zero~libudev+libxml2~nvml~opencl+pci~rocm build_system=autotools libs:=shared,static arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -           ^libfabric@2.2.0~cuda~debug~kdreg~level_zero~uring build_system=autotools fabrics:=sockets,tcp,udp arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -           ^libpciaccess@0.17 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -               ^util-macros@1.20.1 build_system=autotools arch=linux-ubuntu22.04-x86_64 
+ -           ^libxml2@2.13.5~http+pic~python+shared build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -               ^libiconv@1.18 build_system=autotools libs:=shared,static arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -               ^xz@5.6.3~pic build_system=autotools libs:=shared,static arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -           ^yaksa@0.3~cuda~level_zero~rocm build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -               ^autoconf@2.72 build_system=autotools arch=linux-ubuntu22.04-x86_64 
+ -               ^automake@1.16.5 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -               ^libtool@2.4.7 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -               ^m4@1.4.20+sigsegv build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -                   ^libsigsegv@2.14 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -               ^python@3.13.5+bz2+ctypes+dbm~debug+libxml2+lzma~optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tkinter+uuid+zlib build_system=generic arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -                   ^expat@2.7.1+libbsd build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -                       ^libbsd@0.12.2 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                           ^libmd@1.1.0 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                   ^gdbm@1.23 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                   ^libffi@3.4.8 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -                   ^readline@8.3 build_system=autotools patches:=21f0a03 arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                   ^sqlite@3.46.0+column_metadata+dynamic_extensions+fts~functions+rtree build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                   ^util-linux-uuid@2.41 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -       ^pkgconf@2.5.1 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -       ^zlib-ng@2.2.4+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0

--- a/outputs/config/2.externals.out
+++ b/outputs/config/2.externals.out
@@ -1,9 +1,13 @@
-$ spack spec hdf5%clang
- -   hdf5@1.14.5%clang@14.0.0-gfortran cppflags=-g ~cxx~fortran~hl~ipo~java~map~mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64_v3
- -       ^cmake@3.30.5%clang@14.0.0-gfortran cppflags=-g ~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release patches=dbc3892 arch=linux-ubuntu22.04-x86_64_v3
-[e]          ^curl@7.81.0%gcc@11.4.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-ubuntu22.04-x86_64_v3
- -           ^ncurses@6.5%clang@14.0.0-gfortran cppflags=-g ~symlinks+termlib abi=none build_system=autotools patches=7a351bc arch=linux-ubuntu22.04-x86_64_v3
-[e]      ^glibc@2.35%clang@14.0.0-gfortran cppflags=-g  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -       ^gmake@4.4.1%clang@14.0.0-gfortran cppflags=-g ~guile build_system=generic arch=linux-ubuntu22.04-x86_64_v3
- -       ^pkgconf@2.2.0%clang@14.0.0-gfortran cppflags=-g  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -       ^zlib-ng@2.2.1%clang@14.0.0-gfortran cppflags=-g +compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
+$ spack spec hdf5
+ -   hdf5@1.14.6~cxx~fortran~hl~ipo~java~map~mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64 %c=gcc@11.4.0
+ -       ^cmake@3.31.8~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+[e]          ^curl@7.81.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl arch=linux-ubuntu22.04-x86_64
+[e]          ^llvm@14.0.0+clang~cuda~flang+gold+libomptarget~libomptarget_debug~link_llvm_dylib~lld~lldb+llvm_dylib+lua~mlir+polly~python~split_dwarf~z3 build_system=cmake build_type=Release compiler-rt=runtime generator=ninja libcxx=runtime libunwind=runtime openmp=runtime patches:=1f42874,25bc503,6379168,8248141,b216cff,cb8e645 shlib_symbol_version=none targets:=all version_suffix=none arch=linux-ubuntu22.04-x86_64
+ -           ^ncurses@6.5-20250705~symlinks+termlib abi=none build_system=autotools patches:=7a351bc arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -       ^compiler-wrapper@1.0 build_system=generic arch=linux-ubuntu22.04-x86_64
+[e]      ^gcc@11.4.0~binutils+bootstrap~graphite~nvptx~piclibs~profiled~strip build_system=autotools build_type=RelWithDebInfo languages:='c,c++,fortran' arch=linux-ubuntu22.04-x86_64
+ -       ^gcc-runtime@11.4.0 build_system=generic arch=linux-ubuntu22.04-x86_64
+[e]      ^glibc@2.35 build_system=autotools arch=linux-ubuntu22.04-x86_64
+ -       ^gmake@4.4.1~guile build_system=generic arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -       ^pkgconf@2.5.1 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -       ^zlib-ng@2.2.4+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0

--- a/outputs/config/3.prefs.out
+++ b/outputs/config/3.prefs.out
@@ -1,24 +1,21 @@
 $ spack spec hdf5
-Input spec
---------------------------------
- -   hdf5
-
-Concretized
---------------------------------
- -   hdf5@1.14.3%clang@14.0.0-gfortran cppflags="-g" ~cxx~fortran~hl~ipo~java~map~mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64_v3
- -       ^cmake@3.27.7%clang@14.0.0-gfortran cppflags="-g" ~doc+ncurses+ownlibs build_system=generic build_type=Release arch=linux-ubuntu22.04-x86_64_v3
- -           ^curl@8.4.0%clang@14.0.0-gfortran cppflags="-g" ~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs=shared,static tls=openssl arch=linux-ubuntu22.04-x86_64_v3
- -               ^nghttp2@1.57.0%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -               ^openssl@3.1.3%clang@14.0.0-gfortran cppflags="-g" ~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu22.04-x86_64_v3
- -                   ^ca-certificates-mozilla@2023-05-30%clang@14.0.0-gfortran cppflags="-g"  build_system=generic arch=linux-ubuntu22.04-x86_64_v3
- -                   ^perl@5.38.0%clang@14.0.0-gfortran cppflags="-g" +cpanm+opcode+open+shared+threads build_system=generic patches=714e4d1 arch=linux-ubuntu22.04-x86_64_v3
- -                       ^berkeley-db@18.1.40%clang@14.0.0-gfortran cppflags="-g" +cxx~docs+stl build_system=autotools patches=26090f4,b231fcc arch=linux-ubuntu22.04-x86_64_v3
- -                       ^bzip2@1.0.8%clang@14.0.0-gfortran cppflags="-g" ~debug~pic+shared build_system=generic arch=linux-ubuntu22.04-x86_64_v3
- -                           ^diffutils@3.9%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                               ^libiconv@1.17%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools libs=shared,static arch=linux-ubuntu22.04-x86_64_v3
- -                       ^gdbm@1.23%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -                           ^readline@8.2%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools patches=bbf97f1 arch=linux-ubuntu22.04-x86_64_v3
- -           ^ncurses@6.4%clang@14.0.0-gfortran cppflags="-g" ~symlinks+termlib abi=none build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -       ^gmake@4.4.1%clang@14.0.0-gfortran cppflags="-g" ~guile build_system=generic arch=linux-ubuntu22.04-x86_64_v3
- -       ^pkgconf@1.9.5%clang@14.0.0-gfortran cppflags="-g"  build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
- -       ^zlib-ng@2.1.4%clang@14.0.0-gfortran cppflags="-g" +compat+opt build_system=autotools arch=linux-ubuntu22.04-x86_64_v3
+ -   hdf5@1.14.6~cxx~fortran~hl~ipo~java~map~mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -       ^cmake@3.31.8~doc+ncurses+ownlibs~qtgui build_system=generic build_type=Release arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -           ^curl@8.11.1~gssapi~ldap~libidn2~librtmp~libssh~libssh2+nghttp2 build_system=autotools libs:=shared,static tls:=openssl arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -               ^nghttp2@1.65.0 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -                   ^diffutils@3.10 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                       ^libiconv@1.18 build_system=autotools libs:=shared,static arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -               ^openssl@3.4.1~docs+shared build_system=generic certs=mozilla arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -                   ^ca-certificates-mozilla@2025-05-20 build_system=generic arch=linux-ubuntu22.04-x86_64
+ -                   ^perl@5.42.0+cpanm+opcode+open+shared+threads build_system=generic arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                       ^berkeley-db@18.1.40+cxx~docs+stl build_system=autotools patches:=26090f4,b231fcc arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -                       ^bzip2@1.0.8~debug~pic+shared build_system=generic arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                       ^gdbm@1.23 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -                           ^readline@8.3 build_system=autotools patches:=21f0a03 arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -           ^ncurses@6.5-20250705~symlinks+termlib abi=none build_system=autotools patches:=7a351bc arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0
+ -       ^compiler-wrapper@1.0 build_system=generic arch=linux-ubuntu22.04-x86_64
+[e]      ^glibc@2.35 build_system=autotools arch=linux-ubuntu22.04-x86_64
+ -       ^gmake@4.4.1~guile build_system=generic arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+[e]      ^llvm@14.0.0+clang~cuda~flang+gold+libomptarget~libomptarget_debug~link_llvm_dylib~lld~lldb+llvm_dylib+lua~mlir+polly~python~split_dwarf~z3 build_system=cmake build_type=Release compiler-rt=runtime generator=ninja libcxx=runtime libunwind=runtime openmp=runtime patches:=1f42874,25bc503,6379168,8248141,b216cff,cb8e645 shlib_symbol_version=none targets:=all version_suffix=none arch=linux-ubuntu22.04-x86_64
+ -       ^pkgconf@2.5.1 build_system=autotools arch=linux-ubuntu22.04-x86_64 %c=clang@14.0.0
+ -       ^zlib-ng@2.2.4+compat+new_strategies+opt+pic+shared build_system=autotools arch=linux-ubuntu22.04-x86_64 %c,cxx=clang@14.0.0

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -424,7 +424,7 @@ When you have an activated environment, you can edit the associated configuratio
      packages:
        all:
          require:
-         - one_of: ["%llvm", "%gcc"]
+         - any_of: ["%llvm", "%gcc"]
          providers:
            mpi: [mpich, openmpi]
 
@@ -455,13 +455,16 @@ Instead, we'll update our config to force disable it:
      packages:
        all:
          require:
-         - one_of: ["%llvm", "%gcc"]
+         - any_of: ["%llvm", "%gcc"]
          providers:
            mpi: [mpich, openmpi]
        hdf5:
-         require: ~mpi
+         require:
+         - spec: "~mpi"
+         - any_of: ["%llvm", "gcc"]
 
 
+Note that defining ``hdf5`` overrides everything under ``all``, so the Clang preference must be reintroduced.
 Now hdf5 will concretize without an MPI dependency by default.
 
 .. literalinclude:: outputs/config/3.prefs.out
@@ -493,22 +496,27 @@ Let's tell Spack about this package and where it can be found:
      packages:
        all:
          require:
-         - one_of: ["%llvm", "%gcc"]
+         - any_of: ["%llvm", "%gcc"]
          providers:
            mpi: [mpich, openmpi]
        hdf5:
-         require: ~mpi
+         require:
+         - spec: "~mpi"
+         - any_of: ["%llvm", "gcc"]
        curl:
          externals:
          - spec: curl@7.81.0 %gcc@11.4.0
            prefix: /usr
          buildable: false
-
+       cmake:
+         require:
+         - spec: "~qtgui"
 
 Here, we've told Spack that Curl 7.81.0 is installed on our system.
 We've also told it the installation prefix where Curl can be found.
 We don't know exactly which variants it was built with, but that's okay.
 Finally, we set ``buildable: false`` to require that Spack not try to build its own.
+The cmake config isn't strictly required, but you might get a strange concretization without it.
 
 .. The weighting/preferences dont work quite the same so I skipped right to buildable:false
 
@@ -540,7 +548,7 @@ While we're editing the ``spack.yaml`` file, make sure to configure HDF5 to be a
      packages:
        all:
          require:
-         - one_of: ["%llvm", "%gcc"]
+         - any_of: ["%llvm", "%gcc"]
          providers:
            mpi: [mpich, openmpi]
        curl:
@@ -548,6 +556,9 @@ While we're editing the ``spack.yaml`` file, make sure to configure HDF5 to be a
          - spec: curl@7.81.0 %gcc@11.4.0
            prefix: /usr
          buildable: false
+       cmake:
+         require:
+         - spec: "~qtgui"
        mpich:
          externals:
          - spec: mpich@4.0+hydra device=ch4 netmod=ofi

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -461,7 +461,7 @@ Instead, we'll update our config to force disable it:
        hdf5:
          require:
          - spec: "~mpi"
-         - any_of: ["%llvm", "gcc"]
+         - any_of: ["%llvm", "%gcc"]
 
 
 Note that defining ``hdf5`` overrides everything under ``all``, so the Clang preference must be reintroduced.
@@ -486,7 +486,7 @@ On these systems, we have a pre-installed curl.
 Let's tell Spack about this package and where it can be found:
 
 .. code-block:: yaml
-   :emphasize-lines: 14-17
+   :emphasize-lines: 16-20
 
    spack:
      specs: []
@@ -502,7 +502,7 @@ Let's tell Spack about this package and where it can be found:
        hdf5:
          require:
          - spec: "~mpi"
-         - any_of: ["%llvm", "gcc"]
+         - any_of: ["%llvm", "%gcc"]
        curl:
          externals:
          - spec: curl@7.81.0 %gcc@11.4.0

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -378,21 +378,22 @@ First, we will look at the default ``packages.yaml`` file.
 
 .. code-block:: console
 
-   $ spack config --scope defaults edit packages
+   $ spack config --scope=defaults:base edit packages
 
 
 .. literalinclude:: _spack_root/etc/spack/defaults/packages.yaml
    :language: yaml
-   :emphasize-lines: 18,45
+   :emphasize-lines: 51
 
 
-This sets the default preferences for compilers and for providers of virtual packages.
+This sets the default preferences for providers of virtual packages.
+We can edit this to change provider preferences and also to create a preference for compilers.
 To illustrate how this works, suppose we want to change the preferences to prefer the Clang compiler and to prefer MPICH over OpenMPI.
 Currently, we prefer GCC and OpenMPI.
 
 .. literalinclude:: outputs/config/0.prefs.out
    :language: console
-   :emphasize-lines: 16
+   :emphasize-lines: 15
 
 
 Let's override these default preferences in an environment.
@@ -420,9 +421,12 @@ When you have an activated environment, you can edit the associated configuratio
    spack:
      specs: []
      view: true
+     concretizer:
+       unify: true
      packages:
        all:
-         compiler: [clang, gcc, intel, pgi, xl, nag, fj]
+         require:
+         - one_of: ["%llvm", "%gcc"]
          providers:
            mpi: [mpich, openmpi]
 
@@ -431,7 +435,7 @@ Because of the configuration scoping we discussed earlier, this overrides the de
 
 .. literalinclude:: outputs/config/1.prefs.out
    :language: console
-   :emphasize-lines: 18
+   :emphasize-lines: 16
 
 
 ^^^^^^^^^^^^^^^^^^^

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -276,7 +276,8 @@ You can use this new entry like so:
 
    $ spack spec openblas %clang_gfortran
 
-Note the identifier `clang_gfortran` is not itself a spec (you don't version it). You reference it in other specs.
+Note the identifier `clang_gfortran` is not itself a spec (you don't version it).
+You reference it in other specs.
 Note that without `when: '%fortran'`, you could not use `clang_gfortran` with packages unless they depended on Fortran (likewise for the `when` statements on c/cxx).
 
 .. These sections specify when Spack can use different compilers, and are primarily useful for configuration files that will be used across multiple systems.

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -423,8 +423,8 @@ When you have an activated environment, you can edit the associated configuratio
        unify: true
      packages:
        all:
-         require:
-         - any_of: ["%llvm", "%gcc"]
+         prefer:
+         - "%llvm"
          providers:
            mpi: [mpich, openmpi]
 
@@ -454,14 +454,13 @@ Instead, we'll update our config to force disable it:
        unify: true
      packages:
        all:
-         require:
-         - any_of: ["%llvm", "%gcc"]
+         prefer:
+         - "%llvm"
          providers:
            mpi: [mpich, openmpi]
        hdf5:
          require:
          - spec: "~mpi"
-         - any_of: ["%llvm", "%gcc"]
 
 
 Note that defining ``hdf5`` overrides everything under ``all``, so the Clang preference must be reintroduced.
@@ -495,22 +494,18 @@ Let's tell Spack about this package and where it can be found:
        unify: true
      packages:
        all:
-         require:
-         - any_of: ["%llvm", "%gcc"]
+         prefer:
+         - "%llvm"
          providers:
            mpi: [mpich, openmpi]
        hdf5:
          require:
          - spec: "~mpi"
-         - any_of: ["%llvm", "%gcc"]
        curl:
          externals:
          - spec: curl@7.81.0 %gcc@11.4.0
            prefix: /usr
          buildable: false
-       cmake:
-         require:
-         - spec: "~qtgui"
 
 Here, we've told Spack that Curl 7.81.0 is installed on our system.
 We've also told it the installation prefix where Curl can be found.
@@ -547,8 +542,8 @@ While we're editing the ``spack.yaml`` file, make sure to configure HDF5 to be a
        unify: true
      packages:
        all:
-         require:
-         - any_of: ["%llvm", "%gcc"]
+         prefer:
+         - "%llvm"
          providers:
            mpi: [mpich, openmpi]
        curl:
@@ -556,9 +551,6 @@ While we're editing the ``spack.yaml`` file, make sure to configure HDF5 to be a
          - spec: curl@7.81.0 %gcc@11.4.0
            prefix: /usr
          buildable: false
-       cmake:
-         require:
-         - spec: "~qtgui"
        mpich:
          externals:
          - spec: mpich@4.0+hydra device=ch4 netmod=ofi

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -425,11 +425,12 @@ When you have an activated environment, you can edit the associated configuratio
        all:
          prefer:
          - "%llvm"
-         providers:
-           mpi: [mpich, openmpi]
+       mpi:
+         require: mpich
 
+We see if we retry that we now get what we want without getting any more specific on the command line.
 
-Because of the configuration scoping we discussed earlier, this overrides the default settings just for these two items.
+.. Because of the configuration scoping we discussed earlier, this overrides the default settings just for these two items.
 
 .. literalinclude:: outputs/config/1.prefs.out
    :language: console
@@ -445,7 +446,7 @@ If we were working on a project that would routinely need serial HDF5, that migh
 Instead, we'll update our config to force disable it:
 
 .. code-block:: yaml
-   :emphasize-lines: 12-13
+   :emphasize-lines: 12-14
 
    spack:
      specs: []
@@ -456,15 +457,14 @@ Instead, we'll update our config to force disable it:
        all:
          prefer:
          - "%llvm"
-         providers:
-           mpi: [mpich, openmpi]
+       mpi:
+         require: mpich
        hdf5:
          require:
          - spec: "~mpi"
 
 
-Note that defining ``hdf5`` overrides everything under ``all``, so the Clang preference must be reintroduced.
-Now hdf5 will concretize without an MPI dependency by default.
+Note if you define ``require`` under ``all`` and ``hdf5``, you must reintroduce any requirements in ``hdf5``.
 
 .. literalinclude:: outputs/config/3.prefs.out
    :language: console
@@ -485,7 +485,7 @@ On these systems, we have a pre-installed curl.
 Let's tell Spack about this package and where it can be found:
 
 .. code-block:: yaml
-   :emphasize-lines: 16-20
+   :emphasize-lines: 15-19
 
    spack:
      specs: []
@@ -496,8 +496,8 @@ Let's tell Spack about this package and where it can be found:
        all:
          prefer:
          - "%llvm"
-         providers:
-           mpi: [mpich, openmpi]
+       mpi:
+         require: mpich
        hdf5:
          require:
          - spec: "~mpi"
@@ -544,8 +544,8 @@ While we're editing the ``spack.yaml`` file, make sure to configure HDF5 to be a
        all:
          prefer:
          - "%llvm"
-         providers:
-           mpi: [mpich, openmpi]
+       mpi:
+         require: mpich
        curl:
          externals:
          - spec: curl@7.81.0 %gcc@11.4.0

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -180,6 +180,7 @@ We can see overrides in action with:
   $ spack config blame config
 
 .. code-block:: yaml
+
    ---                                                   config:
    /home/spack/.spack/config.yaml:2                        aliases: {}
 

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -510,8 +510,7 @@ Let's tell Spack about this package and where it can be found:
 Here, we've told Spack that Curl 7.81.0 is installed on our system.
 We've also told it the installation prefix where Curl can be found.
 We don't know exactly which variants it was built with, but that's okay.
-Finally, we set `buildable: false` to require that Spack not try to
-build its own.
+Finally, we set `buildable: false` to require that Spack not try to build its own.
 .. The weighting/preferences dont work quite the same so I skipped right to buildable:false
 
 .. literalinclude:: outputs/config/2.externals.out

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -277,9 +277,9 @@ You can use this new entry like so:
 
    $ spack spec openblas %clang_gfortran
 
-Note the identifier `clang_gfortran` is not itself a spec (you don't version it).
+Note the identifier ``clang_gfortran`` is not itself a spec (you don't version it).
 You reference it in other specs.
-Note that without `when: '%fortran'`, you could not use `clang_gfortran` with packages unless they depended on Fortran (likewise for the `when` statements on c/cxx).
+Note that without ``when: '%fortran'``, you could not use ``clang_gfortran`` with packages unless they depended on Fortran (likewise for the `when` statements on c/cxx).
 
 .. These sections specify when Spack can use different compilers, and are primarily useful for configuration files that will be used across multiple systems.
 
@@ -510,7 +510,8 @@ Let's tell Spack about this package and where it can be found:
 Here, we've told Spack that Curl 7.81.0 is installed on our system.
 We've also told it the installation prefix where Curl can be found.
 We don't know exactly which variants it was built with, but that's okay.
-Finally, we set `buildable: false` to require that Spack not try to build its own.
+Finally, we set ``buildable: false`` to require that Spack not try to build its own.
+
 .. The weighting/preferences dont work quite the same so I skipped right to buildable:false
 
 .. literalinclude:: outputs/config/2.externals.out

--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -24,12 +24,10 @@ A partial list of some key configuration sections is provided below.
      - General settings (install location, number of build jobs, etc)
    * - concretizer
      - Specialization of the concretizer behavior (reuse, unification, etc)
-   * - compilers
-     - Define the compilers that Spack can use (required and system specific)
    * - Mirrors
      - Locations where spack can look for stashed source or binary distributions
    * - Packages
-     - Specific settings and rules for packages
+     - Define the compilers that Spack can use, and add rules/preferences for package concretization
    * - Modules
      - Naming, location and additional configuration of Spack generated modules
 


### PR DESCRIPTION
* Right now ~just the compilers part and intro are updated~ everything up to the "Installation Permissions" section is updated (I don't anticipate any major edits in that section or any after)
* For intro:
  * overrides (`::`) use `config:` section as example
* For compilers
  * Compilers are in the `packages:` section
  * And some attributes have moved around inside of it (but generally look the same)
  * can't set `target` in the compiler entry anymore
  * Toolchain example is added for hybrid compiler
* Packages: 
  * concretization examples updated (they are all different because e.g. compiler modeling)
  * preferences for compilers is done differently now (~I use `require:`~ Update August 4: I'm now using `prefer:` and later on using require for `hdf5~mpi`, which is smoother overall)
  * concretizations for `hdf5+mpi ^mpich@4.0` weren't quite the same, so I truncated that part and emphasized the error message (vs. intermediate step where you concretize and don't see `hdf5+mpi`)
* A couple examples that installed things have been updated to just call `spack spec` (pending updates to tutorial image)