### PR TITLE
(revert) basics: update for Spack 1.0 and other minor improvements

### DIFF
--- a/outputs/basics.sh
+++ b/outputs/basics.sh
@@ -28,6 +28,8 @@ example basics/list-py         "spack list 'py-*'"
 # spack install
 example basics/gmake           "spack install gmake"
 
+example basics/compiler-list   "spack compilers"
+
 example basics/mirror          "spack mirror add tutorial /mirror"
 example basics/mirror          "spack buildcache keys --install --trust"
 
@@ -57,7 +59,7 @@ example basics/hdf5-spec       "spack spec hdf5"
 example basics/hdf5            "spack install hdf5"
 example basics/hdf5-no-mpi     "spack install hdf5~mpi"
 
-example basics/hdf5-hl-mpi     "spack install hdf5+hl+mpi ^mpich"
+example basics/hdf5-hl-mpi     "spack install hdf5+hl+mpi %c,cxx=gcc ^mpich"
 
 example basics/find-ldf-2      "spack find -ldf"
 
@@ -96,8 +98,8 @@ example basics/compilers           "spack compilers"
 
 example basics/install-gcc-12.1.0   "spack install gcc@12"
 
-example basics/find-p-gcc          "spack find -p gcc"
+example basics/compilers-2           "spack compilers"
 
-example basics/compiler-add-location 'spack compiler add "$(spack location -i gcc@12)"'
+example basics/spec-zziplib          "spack spec zziplib"
 
-example basics/compiler-remove       'spack compiler remove gcc@12'
+example basics/compiler-uninstall       'spack uninstall gcc@12'


### PR DESCRIPTION
Revert back to #455:

Update basics section for 1.0
 - Move the spack graph demo from hdf5 to tcl, because the hdf5 ASCII graph is no longer legible
 - Discuss compilers as virtuals and virtual assignment syntax
 - Fix all compiler references to direct dependencies.