### PR TITLE
Setup: update to v1.0, hpcic; add a spack tutorial warning

### DIFF
--- a/common/setup.rst
+++ b/common/setup.rst
@@ -17,4 +17,4 @@
    .. warning::
 
       The ``spack tutorial -y`` command is intended for use in a container or VM.
-      It replaces some configuration files in order to establish suitable settings for the tutorial.
+      Use with care in other environments since it replaces some configuration files in order to establish suitable settings for the tutorial.

--- a/common/setup.rst
+++ b/common/setup.rst
@@ -2,16 +2,19 @@
 
    If you have not done the prior sections, you'll need to start the docker image::
 
-       docker run -it ghcr.io/spack/tutorial:pearc25
+       docker run -it ghcr.io/spack/tutorial:hpcic25
 
    and then set Spack up like this::
 
-       git clone --depth=20 --branch=releases/v0.23 https://github.com/spack/spack
+       git clone --depth=20 --branch=releases/v1.0 https://github.com/spack/spack
        . spack/share/spack/setup-env.sh
        spack tutorial -y
        spack bootstrap now
        spack compiler find
 
-   See the :ref:`basics-tutorial` for full details on setup. For more
-   help, join us in the ``#tutorial`` channel on Slack -- get an
-   invitation at `slack.spack.io <https://slack.spack.io/>`_
+   See the :ref:`basics-tutorial` for full details on setup. For more help, join us in the ``#tutorial`` channel on Slack -- get an invitation at `slack.spack.io <https://slack.spack.io/>`_
+
+   .. warning::
+
+      The ``spack tutorial -y`` command is intended for use in a container or VM.
+      It replaces some configuration files in order to establish suitable settings for the tutorial.


### PR DESCRIPTION
This PR updates the common setup for the HPCIC'25 tutorial *and* adds a warning about the use of `spack tutorial -y`.