### PR TITLE
fix: spack config get output

### DIFF
--- a/outputs/environments.sh
+++ b/outputs/environments.sh
@@ -91,7 +91,7 @@ example --tee environments/env-swap-1      "spack env activate myproject"
 spack env activate myproject
 example environments/env-swap-1      "spack find"
 
-example environments/config-get-1    "spack config get | head -12"
+example environments/config-get-1    'cat "$(spack location -e)/spack.yaml"'
 
 # The file is edited by hand here
 # We mock that by using `spack config add`


### PR DESCRIPTION
previous output:

```
$ spack config get | head -12
# This is a Spack Environment file.
#
# It describes a set of packages to be installed, along with
# configuration settings.
spack:
  # add package specs to the `specs` list
  specs:
  - tcl
  - trilinos
  view: true
  concretizer:
    unify: true
==> Error: cannot dump Spack YAML configuration
[Errno 32] Broken pipe
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe
```

This PR cats the environment configuration directly from the spack.yaml file