### PR TITLE
docs: fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,16 @@
 # These dependencies should be installed using pip in order
 # to build the documentation.
-Sphinx==8.2.3
+sphinx==8.2.3
 sphinxcontrib-programoutput==0.18
-furo==2025.7.19
 sphinx-copybutton==0.5.2
+sphinx_design==0.6.1
+furo==2025.7.19
 python-levenshtein==0.27.1
-docutils==0.20.1
-Pygments==2.19.2
+docutils==0.21.2
+pygments==2.19.2
+urllib3==2.5.0
+pytest==8.4.1
+isort==6.0.1
+black==25.1.0
+flake8==7.3.0
+mypy==1.17.1


### PR DESCRIPTION
Fix dependencies allowing us to build the docs with the furo theme.

(Apparently not needed but did show up as a failed build in the readthedocs control center.)