### PR TITLE
packaging: fix inaccurate description of error when debugging the failing mpileaks build

### DIFF
--- a/tutorial_packaging.rst
+++ b/tutorial_packaging.rst
@@ -285,7 +285,7 @@ At this point we need to debug the build problem to determine why Spack cannot i
 Debugging Package Builds
 ------------------------
 
-Our ``tutorial-mpileaks`` package is still not building due to the ``adept-utils`` package's ``configure`` error.
+Our ``tutorial-mpileaks`` package is still not building due to an error in the ``configure`` phase related to ``adept-utils``.
 Experienced Autotools developers will likely already see the problem and its solution.
 
 Let's take this opportunity to use Spack features to investigate the problem.


### PR DESCRIPTION
@kshea21 pointed this out when we were preparing for ICPP a few weeks ago. Wanted to update it before I forgot.