### PR TITLE
Temporarily disable output generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,10 @@ jobs:
     uses: ./.github/workflows/container.yml
 
   outputs:
+    # Output regeneration temporarily disabled — remove the `false` line below to re-enable.
     if: |
-      !cancelled()
+      false
+      && !cancelled()
       && contains(needs.*.result, 'success')
       && !contains(needs.*.result, 'failure')
       && (needs.changes.outputs.outputs == 'true'


### PR DESCRIPTION
Output generation is a bit too aggressive, and tends to increase a lot the noise to signal ratio for PRs by pushing commits like:
- https://github.com/spack/spack-tutorial/pull/536/changes/8f4b1acce210a436cd0536b8f1565bf57be5255b

Here we temporarily disable it.