### PR TITLE
Re-enable a minimal output generation as base for other PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,8 @@ jobs:
     uses: ./.github/workflows/container.yml
 
   outputs:
-    # Output regeneration temporarily disabled — remove the `false` line below to re-enable.
     if: |
-      false
-      && !cancelled()
+      !cancelled()
       && contains(needs.*.result, 'success')
       && !contains(needs.*.result, 'failure')
       && (needs.changes.outputs.outputs == 'true'

--- a/.github/workflows/outputs.yml
+++ b/.github/workflows/outputs.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Re-generate outputs from tutorial scripts
       run: |
         chmod -R a+w outputs
-        mkdir spack-home && sudo chown -R 1000:1000 spack-home
+        mkdir spack-home && sudo chmod -R a+rwx spack-home
         DOCKER_RUN_OPTS="-e COLUMNS=94 -e COLIFY_SIZE=24x94 -v $(pwd)/spack-home:/home/spack"
         make -C outputs -j $(nproc) DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS" container=ghcr.io/spack/tutorial
 
@@ -51,11 +51,11 @@ jobs:
       run: |
         git diff HEAD outputs/
 
-    - name: Push modified files to branch
-      if: ( github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork )
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git add outputs/
-        git commit -m "Update generated outputs on behalf of [@${{ github.actor }}]"
-        git push
+    # - name: Push modified files to branch
+    #   if: ( github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork )
+    #   run: |
+    #     git config user.name "github-actions[bot]"
+    #     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    #     git add outputs/
+    #     git commit -m "Update generated outputs on behalf of [@${{ github.actor }}]"
+    #     git push

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/spack/tutorial-ubuntu-22.04
+FROM ghcr.io/spack/tutorial-ubuntu-26.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -13,12 +13,9 @@ RUN apt-get update -y && \
     vim \
     rclone
 
-# Remove GCC 12 from container
-RUN apt-get remove -y gcc-12
-
 # Download the buildcache
 RUN mkdir /mirror
-RUN rclone copy :s3:spack-binaries/v2025.11.0/tutorial /mirror
+RUN rclone copy :s3:spack-binaries/releases/v2026.06/tutorial /mirror
 
 RUN chmod -R go+r /mirror
 

--- a/outputs/Makefile
+++ b/outputs/Makefile
@@ -35,11 +35,12 @@ update-outputs: run
 run: run-scripting
 run-scripting: run-dev scripting.sh
 # run-cache: run-dev cache.sh
-run-dev: run-packaging dev.sh
-run-packaging: run-stacks packaging.sh
-run-stacks: run-environments stacks.sh
-run-environments: run-basics environments.sh
-run-basics: basics.sh init_spack.sh defs.sh
+run-dev: run-setup dev.sh
+# run-packaging: run-stacks packaging.sh
+# run-stacks: run-environments stacks.sh
+# run-environments: run-basics environments.sh
+# run-basics: basics.sh init_spack.sh defs.sh
+run-setup: init_spack.sh defs.sh
 
 local: local-scripting
 local-scripting: local-dev scripting.sh

--- a/outputs/defs.sh
+++ b/outputs/defs.sh
@@ -14,8 +14,8 @@ fi
 raw_outputs="${PROJECT}/raw"
 
 # used by scripts
-tutorial_branch=releases/v1.1
-packages_release=v2025.11.0
+tutorial_branch=releases/v1.2
+packages_release=releases/v2026.06
 
 print_status() {
     printf "\n%b: %s\n\n" "\033[1;35m$1\033[0m" "$2"


### PR DESCRIPTION
Re-enable a minimal base for output generation CI/CD. Will re-enable other stacks in update PRs to layer on top of this.