### PR TITLE
fix: indent in config section code block

### DIFF
--- a/tutorial_configuration.rst
+++ b/tutorial_configuration.rst
@@ -521,7 +521,7 @@ While we're editing the ``spack.yaml`` file, make sure to configure HDF5 to be a
      concretizer:
        unify: true
      packages:
-      curl:
+       curl:
         externals:
          - spec: curl@7.81.0 %gcc@11.4.0
            prefix: /usr


### PR DESCRIPTION
One of the code blocks in the config section was missing a space in front of `curl`, leading to yaml parsing errors like:

```
==> Error: Invalid environment configuration detected: error parsing YAML: near /home/spack7/spack/var/spack/environments/config-env/spack.yaml, 8, 6: expected <block end>, but found '?' in /home/spack7/spack/var/spack/environments/config-env/spack.yaml
```