### PR TITLE
HPCIC26: Update docs to use signed buildcache in resume setup

### DIFF
--- a/common/setup.rst
+++ b/common/setup.rst
@@ -8,7 +8,8 @@
 
        git clone --depth=2 --branch=releases/v1.2 https://github.com/spack/spack
        . spack/share/spack/setup-env.sh
-       spack mirror add --unsigned tutorial /mirror
+       spack mirror add tutorial /mirror
+       spack buildcache keys --install --trust --yes-to-all
        spack bootstrap now
        spack compiler find
 

--- a/outputs/environments.sh
+++ b/outputs/environments.sh
@@ -11,9 +11,6 @@ export SPACK_COLOR=never
 . "$project/init_spack.sh"
 . share/spack/setup-env.sh
 
-# spack mirror add --unsigned tutorial /mirror
-#example environments/mirror     "spack buildcache keys --install --trust"
-
 # Working with Environments
 
 example environments/find-no-env-1   "spack find"


### PR DESCRIPTION
After swapping back to the signed Tutorial repository for v2026.06.0, I'd forgotten to update the common resume documentation to omit the `--unsigned` flag from the mirror addition.