### PR TITLE
Bump docutils and sphinx together

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,9 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-26.04
   tools:
-    python: "3.11"
+    python: "3.12"
     # You can also specify other tool versions:
     # nodejs: "20"
     # rust: "1.70"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sphinx-last-updated-by-git==0.3.8
 sphinx-sitemap==2.9.0
 furo==2025.12.19
 python-levenshtein==0.27.3
-docutils==0.23
+docutils==0.22
 pygments==2.20.0
 urllib3==2.7.0
 pytest==9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # These dependencies should be installed using pip in order
 # to build the documentation.
-sphinx==8.2.3
+sphinx==9.1.0
 sphinxcontrib-programoutput==0.20
 sphinx-copybutton==0.5.2
 sphinx_design==0.7.0
@@ -9,7 +9,7 @@ sphinx-sitemap==2.9.0
 # fork of furo with a few changes that are not merged upstream
 git+https://github.com/haampie/furo.git@c1d161cb9e04b481ec3331db981aacfa132ecaa6#egg=furo
 python-levenshtein==0.27.3
-docutils==0.21.2
+docutils==0.23
 pygments==2.20.0
 urllib3==2.7.0
 pytest==9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,7 @@ sphinx-copybutton==0.5.2
 sphinx_design==0.7.0
 sphinx-last-updated-by-git==0.3.8
 sphinx-sitemap==2.9.0
-# fork of furo with a few changes that are not merged upstream
-git+https://github.com/haampie/furo.git@c1d161cb9e04b481ec3331db981aacfa132ecaa6#egg=furo
+furo==2025.12.19
 python-levenshtein==0.27.3
 docutils==0.23
 pygments==2.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sphinx-last-updated-by-git==0.3.8
 sphinx-sitemap==2.9.0
 furo==2025.12.19
 python-levenshtein==0.27.3
-docutils==0.22
+docutils==0.22.4
 pygments==2.20.0
 urllib3==2.7.0
 pytest==9.1.1


### PR DESCRIPTION
Sphinx failed when Dependabot attempted to update it due to the older docutils, same for the other way around.